### PR TITLE
인증 연동

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,9 +4,26 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Box } from '@components/box/Box';
 import { theme } from 'stitches.config';
 import Header from '@components/header/Header';
+import { useRouter } from 'next/router';
+import useAuth from '@hooks/useAuth';
+import { useEffect } from 'react';
+import { api } from 'src/api';
 const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+  const { accessToken } = useAuth();
+
+  useEffect(() => {
+    if (!accessToken) {
+      localStorage.setItem('lastUnauthorizedPath', window.location.pathname);
+      router.push(`/auth/login`);
+      return;
+    }
+    // set access token in header
+    api.defaults.headers.common['Authorization'] = accessToken;
+  }, [router, accessToken]);
+
   return (
     <QueryClientProvider client={queryClient}>
       <Box

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,7 @@ import Header from '@components/header/Header';
 import { useRouter } from 'next/router';
 import useAuth from '@hooks/useAuth';
 import { useEffect } from 'react';
-import { api } from 'src/api';
+import { api, playgroundApi } from 'src/api';
 const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps }: AppProps) {
@@ -22,6 +22,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
     // set access token in header
     api.defaults.headers.common['Authorization'] = accessToken;
+    playgroundApi.defaults.headers.common['Authorization'] = accessToken;
   }, [router, accessToken]);
 
   return (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,9 +15,9 @@ function MyApp({ Component, pageProps }: AppProps) {
   const { accessToken } = useAuth();
 
   useEffect(() => {
-    if (!accessToken) {
+    if (accessToken === null) {
       localStorage.setItem('lastUnauthorizedPath', window.location.pathname);
-      router.push(`/auth/login`);
+      window.location.pathname = '/auth/login';
       return;
     }
     // set access token in header

--- a/src/api/group.ts
+++ b/src/api/group.ts
@@ -1,7 +1,6 @@
 import { Option } from '@components/Form/Select/OptionItem';
 import { FormType } from 'src/types/form';
-// TODO: replace with api
-import { apiWithAuth } from '.';
+import { api } from '.';
 
 interface CreateGroupResponse {
   id: number;
@@ -32,10 +31,7 @@ export const createGroup = async (formData: FormType) => {
     }
   }
 
-  const { data } = await apiWithAuth.post<CreateGroupResponse>(
-    '/meeting',
-    form
-  );
+  const { data } = await api.post<CreateGroupResponse>('/meeting', form);
 
   return data;
 };
@@ -63,15 +59,13 @@ interface GetGroupByIdResponse {
 }
 
 export const getGroupById = async (groupId: string) => {
-  const { data } = await apiWithAuth.get<GetGroupByIdResponse>(
-    `/meeting/${groupId}`
-  );
+  const { data } = await api.get<GetGroupByIdResponse>(`/meeting/${groupId}`);
 
   return data;
 };
 
 export const updateGroup = async (groupId: string, formData: FormType) => {
-  const response = await apiWithAuth.put(`/meeting/${groupId}`, {
+  const response = await api.put(`/meeting/${groupId}`, {
     ...formData,
     ...formData.detail,
     category: formData.category.value,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,18 +9,8 @@ const playgroundBaseURL = 'https://playground.api.sopt.org/';
 
 export const api = axios.create({
   baseURL,
-  // withCredentials: true,
 });
 
 export const playgroundApi = axios.create({
   baseURL: playgroundBaseURL,
-});
-
-// accessToken 키가 필요한 요청이 있어서 임시 제작
-export const apiWithAuth = axios.create({
-  baseURL,
-  headers: {
-    Authorization:
-      'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibGVlIiwidXNlcklkIjoxLCJpYXQiOjE2Njg0MzM0MTMsImV4cCI6MTcwNDQzMzQxM30.NGbf96zcykC0QQERvSe5F5S2uZO8Tuc13mkpb73y2Bo',
-  },
 });

--- a/src/api/meeting/index.ts
+++ b/src/api/meeting/index.ts
@@ -1,5 +1,5 @@
 import { RECRUITMENT_STATUS } from '@constants/status';
-import { api, apiWithAuth, PromiseResponse } from '..';
+import { api, PromiseResponse } from '..';
 import { ApplicationStatusType, ApplyResponse, UserResponse } from '../user';
 
 interface PaginationType {
@@ -108,9 +108,8 @@ export const fetchGroupListOfAll = async ({
 };
 
 export const getGroup = async (id: string): Promise<GroupResponse> => {
-  return (
-    await apiWithAuth.get<PromiseResponse<GroupResponse>>(`/meeting/${id}`)
-  ).data.data;
+  return (await api.get<PromiseResponse<GroupResponse>>(`/meeting/${id}`)).data
+    .data;
 };
 
 export const getGroupPeopleList = async ({
@@ -118,33 +117,27 @@ export const getGroupPeopleList = async ({
   ...rest
 }: OptionData): Promise<GroupPeopleResponse> => {
   return (
-    await apiWithAuth.get<PromiseResponse<GroupPeopleResponse>>(
-      `/meeting/${id}/list`,
-      {
-        params: rest,
-      }
-    )
+    await api.get<PromiseResponse<GroupPeopleResponse>>(`/meeting/${id}/list`, {
+      params: rest,
+    })
   ).data.data;
 };
 
 export const deleteGroup = async (
   id: number
 ): Promise<{ statusCode: number }> => {
-  return (await apiWithAuth.delete<{ statusCode: number }>(`/meeting/${id}`))
-    .data;
+  return (await api.delete<{ statusCode: number }>(`/meeting/${id}`)).data;
 };
 
 export const postApplication = async (
   body: PostApplicationRequest
 ): Promise<{ statusCode: number }> => {
-  return (
-    await apiWithAuth.post<{ statusCode: number }>(`/meeting/apply`, body)
-  ).data;
+  return (await api.post<{ statusCode: number }>(`/meeting/apply`, body)).data;
 };
 
 export const updateApplication = async ({
   id,
   ...rest
 }: UpdateApplicationRequest) => {
-  return (await apiWithAuth.put(`/meeting/${id}/apply/status`, rest)).data;
+  return (await api.put(`/meeting/${id}/apply/status`, rest)).data;
 };

--- a/src/api/user/index.ts
+++ b/src/api/user/index.ts
@@ -1,4 +1,4 @@
-import { apiWithAuth, PromiseResponse } from '..';
+import { api, PromiseResponse } from '..';
 import { GroupResponse } from '../meeting';
 
 export interface UserResponse {
@@ -29,13 +29,9 @@ interface GroupListOfMineResponse {
 }
 
 export const fetchGroupListOfApplied = async () => {
-  return apiWithAuth.get<PromiseResponse<GroupListOfAppliedResponse>>(
-    '/users/apply'
-  );
+  return api.get<PromiseResponse<GroupListOfAppliedResponse>>('/users/apply');
 };
 
 export const fetchGroupListOfMine = async () => {
-  return apiWithAuth.get<PromiseResponse<GroupListOfMineResponse>>(
-    '/users/meeting'
-  );
+  return api.get<PromiseResponse<GroupListOfMineResponse>>('/users/meeting');
 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,10 +3,17 @@ import { useEffect, useState } from 'react';
 const ACCESS_TOKEN_KEY = 'serviceAccessToken';
 
 export default function useAuth() {
-  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>('');
 
   useEffect(() => {
+    // TODO: remove after test
+    if (process.env.NODE_ENV === 'development') {
+      setAccessToken(
+        'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibGVlIiwidXNlcklkIjoxLCJpYXQiOjE2Njg0MzM0MTMsImV4cCI6MTcwNDQzMzQxM30.NGbf96zcykC0QQERvSe5F5S2uZO8Tuc13mkpb73y2Bo'
+      );
+    } else {
     setAccessToken(localStorage.getItem(ACCESS_TOKEN_KEY));
+    }
   }, []);
 
   return {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -5,6 +5,11 @@ const ACCESS_TOKEN_KEY = 'serviceAccessToken';
 export default function useAuth() {
   const [accessToken, setAccessToken] = useState<string | null>('');
 
+  const logout = () => {
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    window.location.pathname = '/auth/login';
+  };
+
   useEffect(() => {
     // TODO: remove after test
     if (process.env.NODE_ENV === 'development') {
@@ -12,11 +17,12 @@ export default function useAuth() {
         'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibGVlIiwidXNlcklkIjoxLCJpYXQiOjE2Njg0MzM0MTMsImV4cCI6MTcwNDQzMzQxM30.NGbf96zcykC0QQERvSe5F5S2uZO8Tuc13mkpb73y2Bo'
       );
     } else {
-    setAccessToken(localStorage.getItem(ACCESS_TOKEN_KEY));
+      setAccessToken(localStorage.getItem(ACCESS_TOKEN_KEY));
     }
   }, []);
 
   return {
     accessToken,
+    logout,
   };
 }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+const ACCESS_TOKEN_KEY = 'serviceAccessToken';
+
+export default function useAuth() {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    setAccessToken(localStorage.getItem(ACCESS_TOKEN_KEY));
+  }, []);
+
+  return {
+    accessToken,
+  };
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #71 

## 📋 작업 내용
- [x] 인증 hook 추가
- [x] 인증 토큰이 없다면 localstorage set + 로그인 페이지로 redirect
- [x] 인증 토큰이 있다면 api header 에 추가
- [x] 기존에 api 사용하던 곳 수정

## 📌 PR Point
- 로그인 페이지로 redirect할 때 원래 보고 있던 페이지로 돌아올 수 있도록 location.pathname을 로컬 스토리지에 저장

## 📸 스크린샷

- 인증 연동 테스트 하려면 배포되어야 해서 스샷이 없음.
