### PR TITLE
Crew API 서버에서 제공하는 로그인 API 연동

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,18 +12,21 @@ const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
-  const { accessToken } = useAuth();
+  const {
+    tokens: { playgroundToken, crewToken },
+  } = useAuth();
 
   useEffect(() => {
-    if (accessToken === null) {
+    // NOTE: playground token이 없다면 로그인 페이지로 redirect
+    if (playgroundToken === null) {
       localStorage.setItem('lastUnauthorizedPath', window.location.pathname);
       window.location.pathname = '/auth/login';
       return;
     }
-    // set access token in header
-    api.defaults.headers.common['Authorization'] = accessToken;
-    playgroundApi.defaults.headers.common['Authorization'] = accessToken;
-  }, [router, accessToken]);
+    // 토큰이 존재하면 이를 설정해준다.
+    api.defaults.headers.common['Authorization'] = crewToken;
+    playgroundApi.defaults.headers.common['Authorization'] = playgroundToken;
+  }, [router, playgroundToken, crewToken]);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -1,0 +1,14 @@
+import { api, Data } from '..';
+
+interface GetCrewTokenResponse {
+  accessToken: string;
+}
+
+export const getCrewToken = async (playgroundToken: string) => {
+  const {
+    data: { data },
+  } = await api.post<Data<GetCrewTokenResponse>>(`/auth`, {
+    authToken: playgroundToken,
+  });
+  return data;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 export type PromiseResponse<T> = { data: T; statusCode: number };
+export type Data<T> = PromiseResponse<T>;
 
 // TODO: change after deploy server
 const baseURL = 'https://makers-web.herokuapp.com';

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,9 +1,32 @@
 import { useEffect, useState } from 'react';
+import { getCrewToken } from 'src/api/auth';
 
 const ACCESS_TOKEN_KEY = 'serviceAccessToken';
 
+interface Tokens {
+  playgroundToken: string | null;
+  crewToken: string | null;
+}
+
 export default function useAuth() {
-  const [accessToken, setAccessToken] = useState<string | null>('');
+  const [tokens, setTokens] = useState<Tokens>({
+    playgroundToken: '',
+    crewToken: '',
+  });
+
+  const setAccessTokens = (_tokens: Tokens) => {
+    setTokens({ ...tokens, ..._tokens });
+  };
+
+  const requestCrewToken = async (playgroundToken: string) => {
+    try {
+      const { accessToken: crewToken } = await getCrewToken(playgroundToken);
+      setAccessTokens({ playgroundToken, crewToken });
+    } catch {
+      // TODO: 에러를 어떻게 핸들링하지?
+      alert('계정 정보를 불러오지 못했습니다. 다시 로그인 해주세요.');
+    }
+  };
 
   const logout = () => {
     localStorage.removeItem(ACCESS_TOKEN_KEY);
@@ -11,19 +34,29 @@ export default function useAuth() {
   };
 
   useEffect(() => {
-    // TODO: remove after test
+    // NOTE: development 환경에서는 테스트 토큰을 사용한다.
     if (process.env.NODE_ENV === 'development') {
-      setAccessToken(
-        'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibGVlIiwidXNlcklkIjoxLCJpYXQiOjE2Njg0MzM0MTMsImV4cCI6MTcwNDQzMzQxM30.NGbf96zcykC0QQERvSe5F5S2uZO8Tuc13mkpb73y2Bo'
-      );
-    } else {
-      const token = localStorage.getItem(ACCESS_TOKEN_KEY);
-      setAccessToken(token ? `Bearer ${token}` : null);
+      setTokens({
+        // TODO: 테스트용 playground 토큰이 필요할 듯. 아니면 로컬에서 로그인 되도록 해야할 듯.
+        playgroundToken: '',
+        crewToken:
+          'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibGVlIiwidXNlcklkIjoxLCJpYXQiOjE2Njg0MzM0MTMsImV4cCI6MTcwNDQzMzQxM30.NGbf96zcykC0QQERvSe5F5S2uZO8Tuc13mkpb73y2Bo',
+      });
     }
+    // NOTE: production 에서는 로컬 스토리지에 저장된 토큰을 가져와 사용하고, 이를 바탕으로 모임 서비스 토큰도 발급한다.
+    else {
+      const playgroundToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+      if (!playgroundToken) {
+        setAccessTokens({ playgroundToken: null, crewToken: null });
+        return;
+      }
+      requestCrewToken(playgroundToken);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return {
-    accessToken,
+    tokens,
     logout,
   };
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #89 

## 📋 작업 내용
- [x] crew 로그인(토큰 발급) API 추가
- [x] 액세스 토큰에 접근하는 `useAuth` 훅 추가
- [x] 액세스 토큰을 API request 인스턴스 디폴트 헤더에 추가 및 로그인 페이지 리다이렉션 적용

## 📌 PR Point
- playground 로그인 할때 받은 토큰은 playground API를 찌르는 instance의 헤더에 저장하고, 이 토큰으로 crew 서비스에 한번 더 로그인해서 crew token을 발급받습니다. 이 crew token은 crew API를 찌르는 instance의 헤더에 저장됩니다.
- 토큰이 없으면 로그인 페이지로 redirect 됩니다.
