### PR TITLE
모임 수정 안되는 버그 수정

### DIFF
--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -57,9 +57,9 @@ const EditPage = () => {
   const onSubmit: SubmitHandler<FormType> = async formData => {
     try {
       await mutateAsync({ id, formData });
-
       // TODO: handle success
       alert('모임을 수정했습니다.');
+      router.push(`/detail?id=${id}`);
     } catch (error) {
       // TODO: handle error
       alert('모임을 수정하지 못했습니다.');

--- a/src/api/group.ts
+++ b/src/api/group.ts
@@ -1,8 +1,8 @@
 import { Option } from '@components/Form/Select/OptionItem';
 import { FormType } from 'src/types/form';
-import { api, Data } from '.';
+import { api } from '.';
 
-export const createGroup = async (formData: FormType) => {
+const serializeFormData = (formData: FormType) => {
   const form = new FormData();
   for (const [key, value] of Object.entries(formData)) {
     // NOTE: category는 object 이므로 value만 가져온다.
@@ -27,8 +27,17 @@ export const createGroup = async (formData: FormType) => {
       form.append(key, value);
     }
   }
+  return form;
+};
 
-  const { data } = await api.post<Data<number>>('/meeting', form);
+interface CreateGroupResponse {
+  id: number;
+}
+export const createGroup = async (formData: FormType) => {
+  const { data } = await api.post<CreateGroupResponse>(
+    '/meeting',
+    serializeFormData(formData)
+  );
 
   return data;
 };
@@ -62,12 +71,10 @@ export const getGroupById = async (groupId: string) => {
 };
 
 export const updateGroup = async (groupId: string, formData: FormType) => {
-  const response = await api.put(`/meeting/${groupId}`, {
-    ...formData,
-    ...formData.detail,
-    category: formData.category.value,
-    detail: undefined,
-  });
+  const response = await api.put(
+    `/meeting/${groupId}`,
+    serializeFormData(formData)
+  );
 
   return response;
 };


### PR DESCRIPTION
## 🚩 관련 이슈
- close #101 

## 📋 작업 내용
- [x] 모임 수정 API의 request body의 MIME type을 application/json이 아닌 multipart/formdata로 변경
- [x] 모임 수정하고 나서 해당 모임 페이지로 이동하도록 기능 추가
