### PR TITLE
모집 인원 숫자 입력한 뒤 지울 때 0이 남는 이슈 해결

### DIFF
--- a/src/components/form/Presentation/index.tsx
+++ b/src/components/form/Presentation/index.tsx
@@ -198,7 +198,7 @@ function Presentation({
               error={error?.message}
               {...field}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                field.onChange(+e.target.value)
+                field.onChange(+e.target.value > 0 && +e.target.value)
               }
             />
           )}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #123 

## 📋 작업 내용
- [x] 이슈 해결

## 📌 PR Point
- 이제 ⬇️버튼 눌러도 숫자가 마이너스까지 안 내려갑니다.
- 숫자 입력했다가 지워도 0이 안 남는 거 확인했습니다!