### PR TITLE
모임 참여자 시간 정보 추가

### DIFF
--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -11,8 +11,8 @@ import {
   useQueryGetGroup,
 } from 'src/api/meeting/hooks';
 import { useRouter } from 'next/router';
-import { dateFormat } from '@utils/date';
 import Loader from '@components/loader/Loader';
+import dayjs from 'dayjs';
 
 const DetailPage = () => {
   const router = useRouter();
@@ -31,9 +31,9 @@ const DetailPage = () => {
     {
       id: 1,
       title: '모임 기간',
-      content: `${dateFormat(detailData?.mStartDate ?? '')['YYYY.MM.DD']} - ${
-        dateFormat(detailData?.mEndDate ?? '')['YYYY.MM.DD']
-      }`,
+      content: `${dayjs(detailData?.mStartDate ?? '').format('YYYY.MM.DD')} - ${dayjs(
+        detailData?.mEndDate ?? ''
+      ).format('YYYY.MM.DD')}`,
     },
     {
       id: 2,

--- a/src/components/page/groupDetail/DetailHeader.tsx
+++ b/src/components/page/groupDetail/DetailHeader.tsx
@@ -10,11 +10,11 @@ import RecruitmentStatusList from './RecruitmentStatusList';
 import Textarea from '@components/form/Textarea';
 import Link from 'next/link';
 import { PostApplicationRequest, GroupResponse, UpdateInvitationRequest } from 'src/api/meeting';
-import { dateFormat } from '@utils/date';
 import { EApproveStatus, ERecruitmentStatus, RECRUITMENT_STATUS } from '@constants/option';
 import { AxiosError } from 'axios';
 import { UseMutateFunction, useQueryClient } from '@tanstack/react-query';
 import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
+import dayjs from 'dayjs';
 
 interface DetailHeaderProps {
   detailData: GroupResponse;
@@ -169,7 +169,7 @@ const DetailHeader = ({ detailData, mutateGroupDeletion, mutateApplication, muta
           <div>
             <SRecruitStatus status={status}>{RECRUITMENT_STATUS[status]}</SRecruitStatus>
             <SPeriod>
-              {dateFormat(startDate)['YY.MM.DD']} - {dateFormat(endDate)['YY.MM.DD']}
+              {dayjs(startDate).format('YY.MM.DD')} - {dayjs(endDate).format('YY.MM.DD')}
             </SPeriod>
           </div>
           <h1>

--- a/src/components/page/groupList/Card/index.tsx
+++ b/src/components/page/groupList/Card/index.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@components/box/Box';
 import { Flex } from '@components/util/layout/Flex';
 import { RECRUITMENT_STATUS } from '@constants/option';
-import { dateFormat } from '@utils/date';
+import dayjs from 'dayjs';
 import Link from 'next/link';
 import { ReactNode } from 'react';
 import { GroupResponse } from 'src/api/meeting';
@@ -40,7 +40,7 @@ function Card({ bottom, groupData }: CardProps) {
               <SInfoRow>
                 <SKey>모집 기간</SKey>
                 <SValue>
-                  {dateFormat(groupData.mStartDate)['YY.MM.DD']} - {dateFormat(groupData.mEndDate)['YY.MM.DD']}
+                  {dayjs(groupData.mStartDate).format('YY.MM.DD')} - {dayjs(groupData.mEndDate).format('YY.MM.DD')}
                 </SValue>
               </SInfoRow>
               <SInfoRow>

--- a/src/components/page/groupManagement/ItemDescriptionBox.tsx
+++ b/src/components/page/groupManagement/ItemDescriptionBox.tsx
@@ -8,7 +8,7 @@ const ItemDescriptionBox = () => {
         <SType>유형</SType>
         <SProfile>프로필 (상태)</SProfile>
         <SDetail>상세 내역</SDetail>
-        <span>신청 일자</span>
+        <span>신청 일시</span>
       </div>
       <span>관리</span>
     </SItemDescriptionBox>

--- a/src/components/page/groupManagement/ManagementListItem.tsx
+++ b/src/components/page/groupManagement/ManagementListItem.tsx
@@ -177,13 +177,13 @@ const ManagementListItem = ({ groupId, application, isHost }: ManagementListItem
               <SProfileImage>
                 {user.profileImage ? <img src={user.profileImage} alt="" /> : <ProfileDefaultIcon />}
               </SProfileImage>
-
               <Link href={memberDetail(user.orgId)} passHref>
                 <SName>{user.name}</SName>
               </Link>
             </SProfile>
             <SVerticalLine />
             <SDate>{dateFormat(appliedDate)['YY.MM.DD']}</SDate>
+            <STime>{timeFormat(appliedDate)['HH:MM:SS']}</STime>
           </SUserInformation>
         </SListItem>
       )}
@@ -352,6 +352,12 @@ const STime = styled(Box, {
   marginLeft: '$15',
   fontAg: '18_semibold_100',
   color: '$gray60',
+
+  '@mobile': {
+    marginLeft: '$8',
+    fontAg: '12_medium_100',
+    color: '$gray100',
+  },
 });
 
 const SCardDate = styled(Box, {

--- a/src/components/page/groupManagement/ManagementListItem.tsx
+++ b/src/components/page/groupManagement/ManagementListItem.tsx
@@ -5,7 +5,6 @@ import useModal from '@hooks/useModal';
 import DefaultModal from '@components/modal/DefaultModal';
 import Link from 'next/link';
 import { useState } from 'react';
-import { dateFormat, timeFormat } from '@utils/date';
 import { ApplicationData } from 'src/api/meeting';
 import { APPROVAL_STATUS, APPLICATION_TYPE, EApproveStatus, EApplicationType } from '@constants/option';
 import ArrowMiniIcon from '@assets/svg/arrow_mini.svg';
@@ -13,6 +12,7 @@ import { useMutationUpdateApplication, useMutationDeleteInvitation } from 'src/a
 import { useQueryClient } from '@tanstack/react-query';
 import { SyncLoader } from 'react-spinners';
 import { usePlaygroundLink } from '@hooks/usePlaygroundLink';
+import dayjs from 'dayjs';
 
 interface ManagementListItemProps {
   groupId: number;
@@ -70,8 +70,8 @@ const ManagementListItem = ({ groupId, application, isHost }: ManagementListItem
                 <SUserStatus status={status}>{APPROVAL_STATUS[status]}</SUserStatus>
               </SDesktopProfile>
               <SDetailButton onClick={handleModalOpen}>{APPLICATION_TYPE[type]} 내역</SDetailButton>
-              <SDate>{dateFormat(appliedDate)['YY.MM.DD']}</SDate>
-              <STime>{timeFormat(appliedDate)['HH:MM:SS']}</STime>
+              <SDate>{dayjs(appliedDate).format('YY.MM.DD')}</SDate>
+              <STime>{dayjs(appliedDate).format('HH:mm:ss')}</STime>
             </SUserInformation>
             <SButtonContainer>
               {isMutateLoading ? (
@@ -121,8 +121,8 @@ const ManagementListItem = ({ groupId, application, isHost }: ManagementListItem
                 </div>
                 <div>
                   <SCardType>{APPLICATION_TYPE[type]}</SCardType>
-                  <SCardDate>{dateFormat(appliedDate)['YY.MM.DD']}</SCardDate>
-                  <SCardTime>{timeFormat(appliedDate)['HH:MM:SS']}</SCardTime>
+                  <SCardDate>{dayjs(appliedDate).format('YY.MM.DD')}</SCardDate>
+                  <SCardTime>{dayjs(appliedDate).format('HH:mm:ss')}</SCardTime>
                 </div>
               </SCardUserInformation>
               <SCardDetailButton onClick={handleModalOpen}>
@@ -182,8 +182,8 @@ const ManagementListItem = ({ groupId, application, isHost }: ManagementListItem
               </Link>
             </SProfile>
             <SVerticalLine />
-            <SDate>{dateFormat(appliedDate)['YY.MM.DD']}</SDate>
-            <STime>{timeFormat(appliedDate)['HH:MM:SS']}</STime>
+            <SDate>{dayjs(appliedDate).format('YY.MM.DD')}</SDate>
+            <STime>{dayjs(appliedDate).format('HH:mm:ss')}</STime>
           </SUserInformation>
         </SListItem>
       )}

--- a/src/components/page/groupManagement/ManagementListItem.tsx
+++ b/src/components/page/groupManagement/ManagementListItem.tsx
@@ -174,9 +174,9 @@ const ManagementListItem = ({ groupId, application, isHost }: ManagementListItem
         <SListItem>
           <SUserInformation>
             <SProfile>
-              <SProfileImage>
+              <SGuestProfileImage>
                 {user.profileImage ? <img src={user.profileImage} alt="" /> : <ProfileDefaultIcon />}
-              </SProfileImage>
+              </SGuestProfileImage>
               <Link href={memberDetail(user.orgId)} passHref>
                 <SName>{user.name}</SName>
               </Link>
@@ -264,6 +264,14 @@ const SProfileImage = styled(Box, {
       width: '100%',
       height: '100%',
     },
+  },
+});
+
+const SGuestProfileImage = styled(SProfileImage, {
+  '@mobile': {
+    width: '$24',
+    height: '$24',
+    margin: 0,
   },
 });
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -7,12 +7,3 @@ export function dateFormat(dateString: string) {
     'YY.MM.DD': `${year.slice(2, 4)}.${month}.${day}`,
   };
 }
-
-export function timeFormat(dateString: string) {
-  const hour = dateString.slice(11, 13);
-  const minute = dateString.slice(14, 16);
-  const second = dateString.slice(17, 19);
-  return {
-    'HH:MM:SS': `${hour}:${minute}:${second}`,
-  };
-}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,9 +1,0 @@
-export function dateFormat(dateString: string) {
-  const year = dateString.slice(0, 4);
-  const month = dateString.slice(5, 7);
-  const day = dateString.slice(8, 10);
-  return {
-    'YYYY.MM.DD': `${year}.${month}.${day}`,
-    'YY.MM.DD': `${year.slice(2, 4)}.${month}.${day}`,
-  };
-}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #142 

## 📋 작업 내용
- [x] dateFormat, timeFormat 함수 대신 dayjs 사용하기
- [x] 모임 참여자 조회할 경우에도 시간 정보 나타나도록 수정하기

## 📌 PR Point
- 저번 회의에서 결정한 대로 dateFormat, timeFormat 함수 대신 dayjs를 사용했습니다.
  이제 두 함수가 필요 없어서 date.ts를 제거했습니다!

## 📸 스크린샷
- 데스크탑
  ![image](https://user-images.githubusercontent.com/58380158/221619857-186c43bb-7622-4bd3-b878-5b99c0eeea55.png)

- 모바일
  ![image](https://user-images.githubusercontent.com/58380158/221619936-0dbe6ace-a43f-4d0c-bb53-3aa1a685d913.png)