### PR TITLE
모임 신청 가이드 버튼 추가

### DIFF
--- a/src/components/page/groupList/Filter/Search/index.tsx
+++ b/src/components/page/groupList/Filter/Search/index.tsx
@@ -34,6 +34,7 @@ const SSearchWrapper = styled(Flex, {
   px: '$24',
   border: '1px solid $black40',
   borderRadius: '59px',
+  ml: '$12',
   '@mobile': {
     display: 'none',
   },

--- a/src/components/page/groupList/Filter/index.tsx
+++ b/src/components/page/groupList/Filter/index.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from '@hooks/queryString/custom';
 import Search from './Search';
 import FilterSelect from './Select';
 import Result from './Result';
-import ArrowSmallRightIcon from '@assets/svg/arrow_small_right.svg?rect';
+import ArrowSmallRightIcon from '@assets/svg/arrow_small_right.svg';
 
 export interface FilterType {
   label: string;

--- a/src/components/page/groupList/Filter/index.tsx
+++ b/src/components/page/groupList/Filter/index.tsx
@@ -1,9 +1,11 @@
+import { styled } from 'stitches.config';
 import { Box } from '@components/box/Box';
 import { Flex } from '@components/util/layout/Flex';
 import { useSearchParams } from '@hooks/queryString/custom';
 import Search from './Search';
 import FilterSelect from './Select';
 import Result from './Result';
+import ArrowSmallRightIcon from '@assets/svg/arrow_small_right.svg?rect';
 
 export interface FilterType {
   label: string;
@@ -34,9 +36,13 @@ function Filter() {
           {FILTERS.map(filter => (
             <FilterSelect key={filter.label} filter={filter} />
           ))}
+          <Search />
         </Flex>
-
-        <Search />
+        {/* TODO: href 추가 */}
+        <SGuideButton href="">
+          모임 신청 가이드
+          <ArrowSmallRightIcon />
+        </SGuideButton>
       </Flex>
 
       <Result />
@@ -58,3 +64,23 @@ function Filter() {
 }
 
 export default Filter;
+
+const SGuideButton = styled('a', {
+  flexType: 'verticalCenter',
+  gap: '$8',
+  color: '$purple100',
+  padding: '$18 $20',
+  border: '1px solid $purple100',
+  borderRadius: '14px',
+  fontAg: '18_medium_100',
+
+  '@mobile': {
+    padding: '$15 $10 $15 $16',
+    borderRadius: '10px',
+    fontAg: '14_medium_100',
+  },
+
+  path: {
+    stroke: '$purple100',
+  },
+});

--- a/src/components/page/groupList/Filter/index.tsx
+++ b/src/components/page/groupList/Filter/index.tsx
@@ -39,7 +39,7 @@ function Filter() {
           <Search />
         </Flex>
         {/* TODO: href 추가 */}
-        <SGuideButton href="">
+        <SGuideButton target="_blank" href="" rel="noreferrer noopener">
           모임 신청 가이드
           <ArrowSmallRightIcon />
         </SGuideButton>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #150 

## 📋 작업 내용
- [x] 모임 검색 input 왼쪽으로 옮기기
- [x] 모임 신청 가이드 버튼 추가하기
- [x] 반응형 작업

## 📌 PR Point
- `href`에 들어갈 노션 링크는 아직 전달받지 못해서 나중에 추가하도록 하겠습니다!

## 📸 스크린샷
- 모바일
  ![image](https://user-images.githubusercontent.com/58380158/222411359-1f31f77a-4e12-4efa-8305-b8e0aec6fe06.png)

- 데스크탑
  ![image](https://user-images.githubusercontent.com/58380158/222411528-58f5d5bd-e8be-4a1b-ad20-3a1ff66c6987.png)