### PR TITLE
모임 생성 / 수정 페이지 react-query 적용

### DIFF
--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -125,7 +125,7 @@ const EditPage = () => {
               handleChangeImage={handleChangeImage}
               handleDeleteImage={handleDeleteImage}
               onSubmit={formMethods.handleSubmit(onSubmit)}
-              isSubmitting={isSubmitting}
+              disabled={isSubmitting}
             />
           </SFormWrapper>
         </SFormContainer>

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -26,7 +26,7 @@ const EditPage = () => {
   });
   const { data: formData } = query;
 
-  const { mutateAsync } = useMutation({
+  const { mutateAsync, isLoading: isSubmitting } = useMutation({
     mutationFn: ({ id, formData }: { id: string; formData: FormType }) => updateMeeting(id, formData),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['meeting', id] });
@@ -125,6 +125,7 @@ const EditPage = () => {
               handleChangeImage={handleChangeImage}
               handleDeleteImage={handleDeleteImage}
               onSubmit={formMethods.handleSubmit(onSubmit)}
+              isSubmitting={isSubmitting}
             />
           </SFormWrapper>
         </SFormContainer>

--- a/pages/make/index.tsx
+++ b/pages/make/index.tsx
@@ -4,7 +4,7 @@ import { FormProvider, SubmitHandler, useForm, useWatch } from 'react-hook-form'
 import { FormType, schema } from 'src/types/form';
 import { styled } from 'stitches.config';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { createMeeting as createMeetingApi } from 'src/api/meeting';
+import { createMeeting } from 'src/api/meeting';
 import { useMemo } from 'react';
 import { useRouter } from 'next/router';
 import PlusIcon from 'public/assets/svg/plus.svg';
@@ -17,8 +17,9 @@ const MakePage = () => {
     resolver: zodResolver(schema),
   });
   const { isValid } = formMethods.formState;
-  const { mutateAsync: createMeeting, isLoading: isSubmitting } = useMutation({
-    mutationFn: (formData: FormType) => createMeetingApi(formData),
+  const { mutateAsync: mutateCreateMeeting, isLoading: isSubmitting } = useMutation({
+    mutationFn: (formData: FormType) => createMeeting(formData),
+    onError: () => alert('모임을 개설하지 못했습니다.'),
   });
 
   const files = useWatch({
@@ -43,15 +44,9 @@ const MakePage = () => {
   };
 
   const onSubmit: SubmitHandler<FormType> = async formData => {
-    try {
-      const { data: meetingId } = await createMeeting(formData);
-      alert('모임을 개설했습니다.');
-      router.push(`/detail?id=${meetingId}`);
-      // TODO: handle success
-    } catch (error) {
-      // TODO: handle error
-      alert('모임을 개설하지 못했습니다.');
-    }
+    const { data: meetingId } = await mutateCreateMeeting(formData);
+    alert('모임을 개설했습니다.');
+    router.push(`/detail?id=${meetingId}`);
   };
 
   return (

--- a/pages/make/index.tsx
+++ b/pages/make/index.tsx
@@ -4,19 +4,22 @@ import { FormProvider, SubmitHandler, useForm, useWatch } from 'react-hook-form'
 import { FormType, schema } from 'src/types/form';
 import { styled } from 'stitches.config';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { createMeeting } from 'src/api/meeting';
-import { useMemo, useState } from 'react';
+import { createMeeting as createMeetingApi } from 'src/api/meeting';
+import { useMemo } from 'react';
 import { useRouter } from 'next/router';
 import PlusIcon from 'public/assets/svg/plus.svg';
+import { useMutation } from '@tanstack/react-query';
 
 const MakePage = () => {
   const router = useRouter();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const formMethods = useForm<FormType>({
     mode: 'onChange',
     resolver: zodResolver(schema),
   });
   const { isValid } = formMethods.formState;
+  const { mutateAsync: createMeeting, isLoading: isSubmitting } = useMutation({
+    mutationFn: (formData: FormType) => createMeetingApi(formData),
+  });
 
   const files = useWatch({
     control: formMethods.control,
@@ -40,7 +43,6 @@ const MakePage = () => {
   };
 
   const onSubmit: SubmitHandler<FormType> = async formData => {
-    setIsSubmitting(true);
     try {
       const { data: meetingId } = await createMeeting(formData);
       alert('모임을 개설했습니다.');
@@ -49,8 +51,6 @@ const MakePage = () => {
     } catch (error) {
       // TODO: handle error
       alert('모임을 개설하지 못했습니다.');
-    } finally {
-      setIsSubmitting(false);
     }
   };
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #159 

## 📋 작업 내용
- [x] 모임 생성 API 를 `useMutation` 으로 wrappring
- [x] 모임 수정 페이지에서 `useMutation` 의 `isLoading` 을 presentation의 props로 전달(제출 중 버튼 disable)

## 📌 PR Point
- 리액트 쿼리를 공통적으로 적용하는 리팩토링을 했습니다.