### PR TITLE
모임 생성 / 수정 폼에 대상 기수 입력 필드 추가

### DIFF
--- a/src/components/button/Switch.tsx
+++ b/src/components/button/Switch.tsx
@@ -3,7 +3,7 @@ import { Switch as HeadlessSwitch } from '@headlessui/react';
 import { Fragment } from 'react';
 import { CSSType, styled } from 'stitches.config';
 
-interface SwitchProps {
+export interface SwitchProps {
   css?: CSSType;
   checked: boolean;
   onChange: (value: boolean) => void;

--- a/src/components/form/FormSwitch/FormSwitch.tsx
+++ b/src/components/form/FormSwitch/FormSwitch.tsx
@@ -1,0 +1,40 @@
+import { Switch as HeadlessSwitch } from '@headlessui/react';
+import Switch, { SwitchProps } from '@components/button/Switch';
+import { styled } from 'stitches.config';
+
+interface FormSwitchProps extends SwitchProps {
+  label?: string;
+}
+
+export default function FormSwitch({ label, checked, onChange }: FormSwitchProps) {
+  return (
+    <HeadlessSwitch.Group>
+      <SSwitchWrapper checked={checked}>
+        {label && <SLabel>{label}</SLabel>}
+        <Switch checked={checked} onChange={onChange} />
+      </SSwitchWrapper>
+    </HeadlessSwitch.Group>
+  );
+}
+
+const SSwitchWrapper = styled('div', {
+  padding: '18px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  fontAg: '16_medium_100',
+  color: '$gray100',
+  background: '$black60',
+  borderRadius: '10px',
+  variants: {
+    checked: {
+      true: {
+        color: '$white',
+      },
+    },
+  },
+});
+const SLabel = styled(HeadlessSwitch.Label, {
+  cursor: 'pointer',
+  flexShrink: 0,
+});

--- a/src/components/form/Presentation/index.tsx
+++ b/src/components/form/Presentation/index.tsx
@@ -14,6 +14,7 @@ import ImagePreview from './ImagePreview';
 import { MAX_FILE_SIZE } from 'src/types/form';
 import NeedMentor from '../CheckBox/NeedMentor';
 import { parts } from 'src/data/options';
+import FormSwitch from '../FormSwitch/FormSwitch';
 
 interface PresentationProps {
   submitButtonLabel: React.ReactNode;
@@ -283,12 +284,18 @@ function Presentation({
         </div>
       </div>
 
-      {/* 모임 정보 - 모집 대상 / 대상 파트 */}
+      {/* 모임 정보 - 모집 대상 / 대상 파트 / 대상 기수 */}
       <div>
         <Label required={true} size="small">
           모집 대상
         </Label>
         <STargetFieldWrapper>
+          <FormController
+            name="detail.onlyCurrentGeneration"
+            render={({ field: { value, onChange } }) => (
+              <FormSwitch label="활동 기수만" checked={value} onChange={onChange} />
+            )}
+          ></FormController>
           <FormController
             name="detail.targetPart"
             defaultValue={[parts[0]]}

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -77,6 +77,7 @@ export const schema = z.object({
       })
       .max(300, { message: '300자 까지 입력 가능합니다.' }),
     needMentor: z.boolean().optional().nullable(),
+    onlyCurrentGeneration: z.boolean().optional().nullable(),
     targetPart: z.array(
       z.object({
         label: z.string(),


### PR DESCRIPTION
## 🚩 관련 이슈
- close #185 

## 📋 작업 내용
- [x] 기수 입력 필드(Switch) 추가
- [x] 모임 생성 / 수정 폼가 기수 입력 필드 연동
- [ ] API 연동(API 나오면 진행 예정)

## 📸 스크린샷

https://user-images.githubusercontent.com/31213226/226163945-c7f7be21-d9ff-40f3-9b23-4f05a45a557b.mov

