### PR TITLE
모임 생성 / 수정 '멘토 구해요', '대상 기수', '대상 파트' API 연동

### DIFF
--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -85,6 +85,13 @@ const EditPage = () => {
         return urlToFile(url, `image-${index}.${getExtensionFromUrl(url)}`);
       });
       const files = await Promise.all(filePromises);
+      const joinableParts =
+        // NOTE: null(디폴트), all(전체) 옵션을 제외한 나머지 옵션 개수와 서버에서 내려온 개수가 같으면 '전체' 옵션이 선택된 것 처럼 여겨져야 한다.
+        // NOTE: 그게 아니라면, 서버에서 저장된 옵션에 더해 null(디폴트) 옵션을 추가해준다.
+        parts.length - 2 === formData?.joinableParts.length
+          ? parts
+          : // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            [parts[0], ...formData!.joinableParts.map(partString => parts.find(part => part.value === partString))];
 
       formMethods.reset({
         ...formData,
@@ -100,7 +107,7 @@ const EditPage = () => {
           mEndDate: dayjs(formData?.mEndDate).format('YYYY.MM.DD'),
           leaderDesc: formData?.leaderDesc,
           isMentorNeeded: formData?.isMentorNeeded,
-          joinableParts: formData?.joinableParts.map(partString => parts.find(part => part.value === partString)),
+          joinableParts,
           canJoinOnlyActiveGeneration: formData?.canJoinOnlyActiveGeneration,
           targetDesc: formData?.targetDesc,
           note: formData?.note ?? '',

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -101,6 +101,7 @@ const EditPage = () => {
           leaderDesc: formData?.leaderDesc,
           isMentorNeeded: formData?.isMentorNeeded,
           joinableParts: formData?.joinableParts.map(partString => parts.find(part => part.value === partString)),
+          canJoinOnlyActiveGeneration: formData?.canJoinOnlyActiveGeneration,
           targetDesc: formData?.targetDesc,
           note: formData?.note ?? '',
         },

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -14,6 +14,7 @@ import dayjs from 'dayjs';
 import Loader from '@components/loader/Loader';
 import CheckIcon from 'public/assets/svg/check.svg';
 import dynamic from 'next/dynamic';
+import { parts } from 'src/data/options';
 const DevTool = dynamic(() => import('@hookform/devtools').then(module => module.DevTool), {
   ssr: false,
 });
@@ -99,6 +100,7 @@ const EditPage = () => {
           mEndDate: dayjs(formData?.mEndDate).format('YYYY.MM.DD'),
           leaderDesc: formData?.leaderDesc,
           isMentorNeeded: formData?.isMentorNeeded,
+          joinableParts: formData?.joinableParts.map(partString => parts.find(part => part.value === partString)),
           targetDesc: formData?.targetDesc,
           note: formData?.note ?? '',
         },

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -98,8 +98,7 @@ const EditPage = () => {
           mStartDate: dayjs(formData?.mStartDate).format('YYYY.MM.DD'),
           mEndDate: dayjs(formData?.mEndDate).format('YYYY.MM.DD'),
           leaderDesc: formData?.leaderDesc,
-          // TODO: add field
-          // needMentor: formData.needMentor,
+          isMentorNeeded: formData?.isMentorNeeded,
           targetDesc: formData?.targetDesc,
           note: formData?.note ?? '',
         },

--- a/src/api/meeting/index.ts
+++ b/src/api/meeting/index.ts
@@ -237,12 +237,12 @@ const serializeFormData = (formData: FormType) => {
     else if (key === 'detail') {
       for (const [detailKey, value] of Object.entries(formData[key])) {
         if (detailKey === 'joinableParts') {
-          const refinedParts = formData.detail.joinableParts.filter(part => part.value && part.value !== 'all');
-          for (const part of refinedParts) {
-            part.value && form.append(detailKey, part.value);
-          }
-        }
-        if (value) {
+          const refinedParts = formData.detail.joinableParts
+            // NOTE: value가 null, 'all' 인 것들을 필터링한다
+            .filter(part => part.value && part.value !== 'all')
+            .map(part => part.value) as string[];
+          form.append(detailKey, refinedParts.join(','));
+        } else {
           form.append(detailKey, String(value));
         }
       }

--- a/src/api/meeting/index.ts
+++ b/src/api/meeting/index.ts
@@ -236,6 +236,12 @@ const serializeFormData = (formData: FormType) => {
     // NOTE: nested된 필드를 flat하게 만들어주자.
     else if (key === 'detail') {
       for (const [detailKey, value] of Object.entries(formData[key])) {
+        if (detailKey === 'joinableParts') {
+          const refinedParts = formData.detail.joinableParts.filter(part => part.value && part.value !== 'all');
+          for (const part of refinedParts) {
+            part.value && form.append(detailKey, part.value);
+          }
+        }
         if (value) {
           form.append(detailKey, String(value));
         }

--- a/src/components/form/Presentation/index.tsx
+++ b/src/components/form/Presentation/index.tsx
@@ -294,7 +294,7 @@ function Presentation({
         </Label>
         <STargetFieldWrapper>
           <FormController
-            name="detail.onlyCurrentGeneration"
+            name="detail.canJoinOnlyActiveGeneration"
             render={({ field: { value, onChange } }) => (
               <FormSwitch label="활동 기수만" checked={value} onChange={onChange} />
             )}

--- a/src/components/form/Presentation/index.tsx
+++ b/src/components/form/Presentation/index.tsx
@@ -300,7 +300,7 @@ function Presentation({
             )}
           ></FormController>
           <FormController
-            name="detail.targetPart"
+            name="detail.joinableParts"
             defaultValue={[parts[0]]}
             render={({ field: { value, onChange, onBlur } }) => (
               <Select options={parts} value={value} onChange={onChange} onBlur={onBlur} multiple />

--- a/src/components/form/Presentation/index.tsx
+++ b/src/components/form/Presentation/index.tsx
@@ -268,7 +268,10 @@ function Presentation({
         </Label>
         <div style={{ position: 'relative' }}>
           <SNeedMentorFieldWrapper>
-            <FormController name="detail.needMentor" render={({ field }) => <NeedMentor {...field} />}></FormController>
+            <FormController
+              name="detail.isMentorNeeded"
+              render={({ field }) => <NeedMentor {...field} />}
+            ></FormController>
           </SNeedMentorFieldWrapper>
           <FormController
             name="detail.leaderDesc"

--- a/src/data/options.ts
+++ b/src/data/options.ts
@@ -20,10 +20,10 @@ export const generationOptions = [
 export const parts = [
   { label: '대상 파트', value: null },
   { label: '전체', value: 'all', order: 1 },
-  { label: '기획', value: '기획', order: 2 },
-  { label: '디자인', value: '디자인', order: 3 },
-  { label: '웹', value: '웹', order: 4 },
-  { label: '안드로이드', value: '안드로이드', order: 5 },
-  { label: 'iOS', value: 'iOS', order: 6 },
-  { label: '서버', value: '서버', order: 7 },
+  { label: '기획', value: 'PM', order: 2 },
+  { label: '디자인', value: 'DESIGN', order: 3 },
+  { label: '웹', value: 'WEB', order: 4 },
+  { label: '안드로이드', value: 'ANDROID', order: 5 },
+  { label: 'iOS', value: 'IOS', order: 6 },
+  { label: '서버', value: 'SERVER', order: 7 },
 ];

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -76,7 +76,7 @@ export const schema = z.object({
         message: '개설자 소개를 입력해주세요.',
       })
       .max(300, { message: '300자 까지 입력 가능합니다.' }),
-    needMentor: z.boolean().optional().nullable(),
+    isMentorNeeded: z.boolean().optional().nullable(),
     onlyCurrentGeneration: z.boolean().optional().nullable(),
     targetPart: z.array(
       z.object({

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -78,10 +78,10 @@ export const schema = z.object({
       .max(300, { message: '300자 까지 입력 가능합니다.' }),
     isMentorNeeded: z.boolean().optional().nullable(),
     onlyCurrentGeneration: z.boolean().optional().nullable(),
-    targetPart: z.array(
+    joinableParts: z.array(
       z.object({
         label: z.string(),
-        value: z.string(),
+        value: z.string().nullable(),
       })
     ),
     targetDesc: z

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -77,7 +77,7 @@ export const schema = z.object({
       })
       .max(300, { message: '300자 까지 입력 가능합니다.' }),
     isMentorNeeded: z.boolean().optional().nullable(),
-    onlyCurrentGeneration: z.boolean().optional().nullable(),
+    canJoinOnlyActiveGeneration: z.boolean().optional().nullable(),
     joinableParts: z.array(
       z.object({
         label: z.string(),


### PR DESCRIPTION
## 🚩 관련 이슈
- close #181 #187 #195 

## 📋 작업 내용
- [x] 폼 스키마 필드 이름을 API에 맞게 수정
- [x] 대상 파트(`joinableParts`)의 경우 데이터를 서버와 주고받을 때 알맞게 적용할 수 있도록 정제하는 로직 추가

## 📸 스크린샷


https://user-images.githubusercontent.com/31213226/226677901-8524f3d4-c5d4-42d2-bea2-a77def680b8d.mov

