### PR TITLE
모임 생성 시 체크박스 필드('대상 기수', '멘토 구해요')에 한번 체크해야 제출 버튼 활성화 되는 이슈 수정

### DIFF
--- a/src/components/form/FormController/index.tsx
+++ b/src/components/form/FormController/index.tsx
@@ -1,15 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Controller, ControllerProps, useFormContext } from 'react-hook-form';
 import { Option } from '../Select/OptionItem';
 
 interface FormControllerProps {
   name: string;
   render: ControllerProps['render'];
-  defaultValue?: string | number | Option | Option[];
+  defaultValue?: boolean | string | number | Option | Option[];
 }
 
 function FormController({ name, render, defaultValue }: FormControllerProps) {
-  const { control, formState } = useFormContext();
+  const { control, formState, setValue } = useFormContext();
+
+  useEffect(() => {
+    if (defaultValue === false) {
+      setValue(name, false);
+    }
+  }, [defaultValue, name, setValue]);
 
   return (
     <Controller

--- a/src/components/form/Presentation/index.tsx
+++ b/src/components/form/Presentation/index.tsx
@@ -270,6 +270,7 @@ function Presentation({
           <SNeedMentorFieldWrapper>
             <FormController
               name="detail.isMentorNeeded"
+              defaultValue={false}
               render={({ field }) => <NeedMentor {...field} />}
             ></FormController>
           </SNeedMentorFieldWrapper>
@@ -295,6 +296,7 @@ function Presentation({
         <STargetFieldWrapper>
           <FormController
             name="detail.canJoinOnlyActiveGeneration"
+            defaultValue={false}
             render={({ field: { value, onChange } }) => (
               <FormSwitch label="활동 기수만" checked={value} onChange={onChange} />
             )}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #215 

## 📋 작업 내용
- [x] 폼 체크박스 필드에 `defaultValue` 설정
- [x] `FormController` 에서 `defaultValue` 로 `boolean` 도 받을 수 있도록 props 수정 및 이펙트 추가

## 📌 PR Point
- 이슈의 원인은 기본값이 undefined 여서 폼이 not valid 하다고 판단했기 때문에 발생했음
- 그래서 체크박스 디폴트 값을 `false` 로 부여했지만, 여전히 동작하지 않았고, 조사 결과 라이브러리 Github 레포에 이슈가 올라와있었음(링크: https://github.com/react-hook-form/react-hook-form/issues/7337#issuecomment-999275751)
- 해당 이슈에서 메인테이너가 안내하는 해결 방법을 적용함(`defaultValue`가 `false` 라면 `setValue()` 메서드로 값을 설정하는 이펙트 추가)
