### PR TITLE
Safari에서 날짜 입력 시 에러나는 버그 수정

### DIFF
--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -1,5 +1,7 @@
 import dayjs from 'dayjs';
 import { z } from 'zod';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+dayjs.extend(customParseFormat);
 
 export const schema = z.object({
   title: z


### PR DESCRIPTION
## 🚩 관련 이슈
- close #229 

## 📋 작업 내용
- [x] dayjs 커스텀 플러그인 추가

## 📌 PR Point
- 사파리 브라우저가 `Date()` 파싱 잘 못하는 버그가 있었습니다.
- 그래서 관련 이슈가 dayjs에도 올라와 있었고, 해당 [이슈](https://github.com/iamkun/dayjs/issues/1822)에서 제안하는 [솔루션](https://github.com/iamkun/dayjs/issues/1822#issuecomment-1082731428)을 적용했습니다(커스텀 플러그인 사용)
