### PR TITLE
텍스트를 클릭 가능한 링크로 변환하기

### DIFF
--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -68,6 +68,22 @@ const DetailPage = () => {
     tabRef.current[detailList.findIndex(item => item.title === text)].scrollIntoView({ behavior: 'smooth' });
   };
 
+  const handleContent = (content: string) => {
+    const urlRegex = /(https?:\/\/[^\s]+)|(www\.[^\s]+)/g;
+    const fragmentList = content.split(urlRegex);
+    return fragmentList.map((fragment, index) => {
+      if (urlRegex.test(fragment)) {
+        const url = fragment.startsWith('https') ? fragment : `https://${fragment}`;
+        return (
+          <a key={index} href={url} target="_blank" rel="noopener noreferrer">
+            {fragment}
+          </a>
+        );
+      }
+      return fragment;
+    });
+  };
+
   if (!detailData) {
     return <Loader />;
   }
@@ -104,7 +120,7 @@ const DetailPage = () => {
                   <span>대상 파트</span> : {partList?.join(', ')}
                 </STarget>
               )}
-              <SDescription>{content}</SDescription>
+              <SDescription>{handleContent(content)}</SDescription>
             </SDetail>
           )
       )}
@@ -145,6 +161,10 @@ const STitle = styled('h2', {
 const SDescription = styled('p', {
   fontAg: '22_regular_170',
   whiteSpace: 'pre-line',
+
+  a: {
+    textDecoration: 'underline',
+  },
 
   '@mobile': {
     fontAg: '16_medium_150',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #244 

## 📋 작업 내용
- [x] 모임 상세 페이지의 모임 설명 텍스트에서 링크 부분은 클릭할 수 있게 만들기

## 📌 PR Point
- 정규 표현식 urlRegex를 사용해 content에서 url을 찾는 방식으로 구현했습니다.

## 📸 스크린샷
|Before|After|
|:-:|:-:|
|![image](https://user-images.githubusercontent.com/58380158/227838722-ec982e48-8851-4476-b4c9-da4b65361632.png)|![image](https://user-images.githubusercontent.com/58380158/227838648-1d32bdec-99fb-4d6d-b843-5840fe194ffa.png)|
