### PR TITLE
pagination moveBundle 로직 수정

### DIFF
--- a/src/components/page/meetingList/Pagination.tsx
+++ b/src/components/page/meetingList/Pagination.tsx
@@ -16,7 +16,7 @@ function Pagination({ totalPagesLength = 1, currentPageIndex = 1, changeCurrentP
 
   const pagesBundle = bindThePages(totalPagesLength, BUNDLE_SIZE);
   const prevBundle = () => {
-    const prevBundleLastPage = (parseInt(String((currentPageIndex - 1) / BUNDLE_SIZE)) - 1) * BUNDLE_SIZE + BUNDLE_SIZE;
+    const prevBundleLastPage = Math.floor((currentPageIndex - 1) / BUNDLE_SIZE) * BUNDLE_SIZE;
     changeCurrentPage(prevBundleLastPage);
   };
   const nextBundle = () => {

--- a/src/components/page/meetingList/Pagination.tsx
+++ b/src/components/page/meetingList/Pagination.tsx
@@ -20,7 +20,7 @@ function Pagination({ totalPagesLength = 1, currentPageIndex = 1, changeCurrentP
     changeCurrentPage(prevBundleLastPage);
   };
   const nextBundle = () => {
-    const nextBundleFirstPage = (parseInt(String((currentPageIndex - 1) / BUNDLE_SIZE)) + 1) * BUNDLE_SIZE + 1;
+    const nextBundleFirstPage = Math.ceil(currentPageIndex / BUNDLE_SIZE) * BUNDLE_SIZE + 1;
     changeCurrentPage(nextBundleFirstPage);
   };
 

--- a/src/components/page/meetingList/Pagination.tsx
+++ b/src/components/page/meetingList/Pagination.tsx
@@ -16,10 +16,12 @@ function Pagination({ totalPagesLength = 1, currentPageIndex = 1, changeCurrentP
 
   const pagesBundle = bindThePages(totalPagesLength, BUNDLE_SIZE);
   const prevBundle = () => {
-    changeCurrentPage(currentPageIndex - BUNDLE_SIZE);
+    const prevBundleLastPage = (parseInt(String((currentPageIndex - 1) / BUNDLE_SIZE)) - 1) * BUNDLE_SIZE + BUNDLE_SIZE;
+    changeCurrentPage(prevBundleLastPage);
   };
   const nextBundle = () => {
-    changeCurrentPage(currentPageIndex + BUNDLE_SIZE);
+    const nextBundleFirstPage = (parseInt(String((currentPageIndex - 1) / BUNDLE_SIZE)) + 1) * BUNDLE_SIZE + 1;
+    changeCurrentPage(nextBundleFirstPage);
   };
 
   const handlePageLinkClick = (item: number) => {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #256 

## 📋 작업 내용
- [x] pagination bundle 로직 수정

## 📌 PR Point
- 만약 전의 로직이라면 마지막 페이지가 7페이지라고 했을떄, 4에서 누르면 페이지가 9로 이동하게 되는 오류가 생각났어요. 
- 그래서 다음 pagebundle의 첫번째로 이동하도록 만들었어요
- 마찬가지로 prevBundle 함수도 전 pagebundle의 마지막으로 이동하게 만들었어요.

## 📸 스크린샷
