### PR TITLE
크루 토큰을 로컬 스토리지에 저장하지 않도록 수정

### DIFF
--- a/src/components/util/auth.ts
+++ b/src/components/util/auth.ts
@@ -11,14 +11,9 @@ export const getPlaygroundToken = () => {
 };
 
 export const getCrewServiceToken = async (playgroundToken: string) => {
-  const crewToken = localStorage.getItem(CREW_ACCESS_TOKEN_KEY);
-  if (crewToken) {
-    return crewToken;
-  }
   // NOTE: crewToken이 없으면 playground Token으로 로그인 시도
   try {
     const { accessToken: crewToken } = await getCrewToken(playgroundToken);
-    localStorage.setItem(CREW_ACCESS_TOKEN_KEY, crewToken);
     return crewToken;
   } catch {
     // TODO: 에러를 어떻게 핸들링하지?


### PR DESCRIPTION
## 🚩 관련 이슈
- close #274 

## 📋 작업 내용
- [x] 크루 토큰을 발급할 때 로컬 스토리지에 저장하지 않도록 수정(즉, 모임 서비스에 접속할 때 마다 매번 새로 크루 토큰을 발급함)

## 📌 PR Point
- 프로필을 추후에 작성하는 유저의 정보를 정상적으로 반영하기 위해 변경
