### PR TITLE
개발 환경 배포 액션 수정

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: yarn build:ci
       - name: Publish
-        run: yarn run wrangler pages publish "out" --project-name "${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}" --commit-message "${{ github.sha }}"
+        run: yarn run wrangler pages publish "out" --project-name "${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}" --commit-message "${{ github.sha }}" --branch=main
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -32,6 +32,8 @@ jobs:
           echo "NEXT_PUBLIC_APP_ENV=development" >> .env
       - name: Build
         run: yarn build:ci
+      - name: Move artifacts into dist folder
+        run: mkdir group && mv out/* group/ && mv group out
       - name: Publish
         run: yarn run wrangler pages publish "out" --project-name "${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}" --commit-message "${{ github.sha }}" --branch=main
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,6 +32,8 @@ jobs:
           echo "NEXT_PUBLIC_APP_ENV=production" > .env
       - name: Build
         run: yarn build:ci
+      - name: Move artifacts into dist folder
+        run: mkdir group && mv out/* group/ && mv group out
       - name: Publish
         run: yarn run wrangler pages publish "out" --project-name "${{ secrets.CLOUDFLARE_PAGES_PROJECT_NAME }}" --commit-message "${{ github.sha }}"
         env:


### PR DESCRIPTION
## 📋 작업 내용
- [x] publish job의 커맨드에 옵션으로 `--branch=main` 을 제공해주었습니다.
- [x] `next export` 명령으로 뽑아낸 static site가 basePath 를 지원할 수 있도록 `/group` 디렉토리로 옮기는 step을 dev / prod 배포 액션에 추가했습니다.

## 📌 PR Point
- `sopt-crew-dev` cf pages가 현재 preview로만 동작하고 있어서, production 환경으로 배포할 수 있도록 수정합니다.([관련 내용](https://community.cloudflare.com/t/pages-direct-upload-cant-set-the-production-branch-name/402072/3))
- next export 로 빌드 명령을 변경한 것이 잘 반영되어 배포될 수 있도록 배포 액션을 수정합니다.
