### PR TITLE
아바타 컴포넌트 구현

### DIFF
--- a/src/components/avatar/Avatar.stories.ts
+++ b/src/components/avatar/Avatar.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Avatar from './Avatar';
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
+const meta: Meta<typeof Avatar> = {
+  title: 'Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
+export const Default: Story = {
+  args: {
+    src: 'https://mui.com/static/images/avatar/1.jpg',
+    alt: 'Avatar',
+  },
+};
+
+export const CustomStyles: Story = {
+  args: {
+    src: 'https://mui.com/static/images/avatar/1.jpg',
+    alt: 'Avatar',
+    sx: {
+      width: '48px',
+      height: '48px',
+    },
+  },
+};

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -20,14 +20,7 @@ const SContainer = styled('div', {
   height: '32px',
   borderRadius: '50%',
   overflow: 'hidden',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  img: {
-    width: '100%',
-    height: '100%',
-    objectFit: 'cover',
-  },
+  flexType: 'center',
 });
 const SImage = styled('img', {
   width: '100%',

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,0 +1,36 @@
+import { CSSProperties } from 'react';
+import { styled } from 'stitches.config';
+
+interface AvatarProps {
+  src: string;
+  alt: string;
+  sx?: CSSProperties;
+}
+
+export default function Avatar({ src, alt, sx }: AvatarProps) {
+  return (
+    <SContainer style={sx}>
+      <SImage src={src} alt={alt} />
+    </SContainer>
+  );
+}
+
+const SContainer = styled('div', {
+  width: '32px',
+  height: '32px',
+  borderRadius: '50%',
+  overflow: 'hidden',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  img: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+  },
+});
+const SImage = styled('img', {
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+});

--- a/src/components/avatar/AvatarGroup.stories.tsx
+++ b/src/components/avatar/AvatarGroup.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import AvatarGroup from './AvatarGroup';
+import Avatar from './Avatar';
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
+const meta: Meta<typeof AvatarGroup> = {
+  title: 'AvatarGroup',
+  component: AvatarGroup,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AvatarGroup>;
+
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
+export const Default: Story = {
+  args: {
+    children: [
+      <Avatar
+        src="https://mui.com/static/images/avatar/1.jpg"
+        alt="sample iamge"
+        sx={{ width: '48px', height: '48px' }}
+      />,
+      <Avatar
+        src="https://mui.com/static/images/avatar/2.jpg"
+        alt="sample iamge"
+        sx={{ width: '48px', height: '48px' }}
+      />,
+      <Avatar
+        src="https://mui.com/static/images/avatar/3.jpg"
+        alt="sample iamge"
+        sx={{ width: '48px', height: '48px' }}
+      />,
+    ],
+  },
+};

--- a/src/components/avatar/AvatarGroup.tsx
+++ b/src/components/avatar/AvatarGroup.tsx
@@ -1,0 +1,24 @@
+import { Children, PropsWithChildren } from 'react';
+import { styled } from 'stitches.config';
+
+export default function AvatarGroup({ children }: PropsWithChildren) {
+  return (
+    <SContainer>
+      {Children.map(children, (child, index) => (
+        <SAvatarWrapper key={index} style={{ transform: `translateX(-${33 * index}%)` }}>
+          {child}
+        </SAvatarWrapper>
+      ))}
+    </SContainer>
+  );
+}
+
+const SContainer = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+});
+const SAvatarWrapper = styled('div', {
+  '& > div': {
+    border: '3px solid $black100',
+  },
+});


### PR DESCRIPTION
## 🚩 관련 이슈
- close #347 

## 📋 작업 내용
- [x] 단일 아바타 컴포넌트 추가(`<Avatar />`)
- [x] 아바타 그룹 컴포넌트 추가(`<AvatarGroup />`)
- [x] 아바타 컴포넌트 스토리 추가

## 📌 PR Point
- 단일 아바타 컴포넌트는 그냥 동그란 이미지 컴포넌트입니다. 이름, 몇 시간 전 수정 등 메타 정보들은 사용하는 쪽에서 자유롭게 추가하도록 합니다(인터페이스를 따로 뚫진 않았어요. 그게 더 복잡할 것 같아서)
- 그룹 아바타 컴포넌트는 아바타 컴포넌트들을 자식으로 갖습니다. 
```tsx
<AvatarGroup>
    <Avatar src="https://mui.com/static/images/avatar/1.jpg" alt="sample iamge" />
    <Avatar src="https://mui.com/static/images/avatar/2.jpg" alt="sample iamge" />
    <Avatar src="https://mui.com/static/images/avatar/3.jpg" alt="sample iamge" />
</AvatarGroup>
```
- 인터페이스는 [MUI](https://mui.com/material-ui/react-avatar/)를 참고했어요.

## 📸 스크린샷
<img width="1728" alt="Screenshot 2023-06-25 at 5 06 15 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/0d03dae4-aa9e-4de5-8136-09a2a30343b1">
<img width="1728" alt="Screenshot 2023-06-25 at 5 06 22 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/dba03587-cb28-453c-8379-56e56be4228b">


