### PR TITLE
피드, 모임 안내 탭 추가

### DIFF
--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -1,73 +1,20 @@
 import { Box } from '@components/box/Box';
 import DetailHeader from '@components/page/meetingDetail/DetailHeader';
 import Carousel from '@components/page/meetingDetail/Carousel';
-import { TabList } from '@components/tabList/TabList';
-import { useRef, useState } from 'react';
 import { styled } from 'stitches.config';
 import { useMutationDeleteMeeting, useMutationPostApplication, useQueryGetMeeting } from '@api/meeting/hooks';
 import { useRouter } from 'next/router';
 import Loader from '@components/loader/Loader';
-import dayjs from 'dayjs';
-import 'dayjs/locale/ko';
-dayjs.locale('ko');
-import { PART_NAME } from '@constants/option';
-import { parseTextToLink } from '@components/util/parseTextToLink';
-import { useDisplay } from '@hooks/useDisplay';
+import InformationPanel from '@components/page/meetingDetail/InformationPanel';
+import { Tab } from '@headlessui/react';
+import FeedPanel from '@components/page/meetingDetail/FeedPanel';
 
 const DetailPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
-  const { isMobile } = useDisplay();
   const { data: detailData } = useQueryGetMeeting({ params: { id } });
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
-  const tabRef = useRef<HTMLElement[]>([]);
-  const detailList = [
-    {
-      id: 0,
-      title: '모임 소개',
-      content: detailData?.desc,
-    },
-    {
-      id: 1,
-      title: '활동 기간',
-      content: `${dayjs(detailData?.mStartDate ?? '').format('YYYY.MM.DD (ddd)')} ~ ${dayjs(
-        detailData?.mEndDate ?? ''
-      ).format('YYYY.MM.DD (ddd)')}`,
-    },
-    {
-      id: 2,
-      title: '진행 방식',
-      content: detailData?.processDesc,
-    },
-    {
-      id: 3,
-      title: '모집 대상',
-      generation: detailData?.canJoinOnlyActiveGeneration ? '활동 기수' : '전체',
-      partList: detailData?.joinableParts?.map(key => PART_NAME[key]),
-      content: detailData?.targetDesc,
-    },
-    {
-      id: 4,
-      title: '개설자 소개',
-      content: detailData?.leaderDesc,
-    },
-    {
-      id: 5,
-      title: '유의사항',
-      content: detailData?.note,
-    },
-  ];
-  const [selectedTab, setSelectedTab] = useState(detailList[0].title);
-
-  const handleChange = (text: string) => {
-    setSelectedTab(text);
-    tabRef.current[detailList.findIndex(item => item.title === text)].scrollIntoView({ behavior: 'smooth' });
-  };
-
-  const handleContent = (content: string) => {
-    return parseTextToLink(content);
-  };
 
   if (!detailData) {
     return <Loader />;
@@ -81,35 +28,24 @@ const DetailPage = () => {
         mutateMeetingDeletion={mutateDeleteMeeting}
         mutateApplication={mutatePostApplication}
       />
-      {isMobile && (
-        <TabList text={selectedTab} size="small" onChange={handleChange}>
-          {detailList.map(
-            ({ id, title, content }) =>
-              content && (
-                <TabList.Item key={id} text={title}>
-                  {title}
-                </TabList.Item>
-              )
-          )}
-        </TabList>
-      )}
-      {detailList.map(
-        ({ id, title, generation, partList, content }) =>
-          content && (
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            <SDetail key={id} ref={element => (tabRef.current[id] = element!)}>
-              <STitle>{title}</STitle>
-              {title === '모집 대상' && (
-                <STarget>
-                  <span>대상 기수</span> : {generation}
-                  <br />
-                  <span>대상 파트</span> : {partList?.join(', ')}
-                </STarget>
-              )}
-              <SDescription>{handleContent(content)}</SDescription>
-            </SDetail>
-          )
-      )}
+      <Tab.Group
+        onChange={index => {
+          console.log('Changed selected tab to:', index);
+        }}
+      >
+        <STabList>
+          <STab>피드</STab>
+          <STab>모임 안내</STab>
+        </STabList>
+        <Tab.Panels>
+          <Tab.Panel>
+            <FeedPanel />
+          </Tab.Panel>
+          <Tab.Panel>
+            <InformationPanel detailData={detailData} />
+          </Tab.Panel>
+        </Tab.Panels>
+      </Tab.Group>
     </SDetailPage>
   );
 };
@@ -124,51 +60,38 @@ const SDetailPage = styled(Box, {
   },
 });
 
-const SDetail = styled('section', {
-  scrollMarginTop: '$80',
-  color: '$white100',
-  mt: '$120',
-
-  '@tablet': {
-    mt: '$56',
-  },
+const STabList = styled(Box, {
+  display: 'flex',
 });
 
-const STitle = styled('h2', {
-  fontAg: '24_bold_100',
-  mb: '$24',
+const STab = styled(Tab, {
+  pb: '$16',
+  mr: '$20',
+  fontStyle: 'H1',
+  flex: '1',
+  textAlign: 'center',
+  color: '$gray100',
 
-  '@tablet': {
-    fontAg: '16_bold_100',
-    mb: '$20',
-  },
-});
-
-const SDescription = styled('p', {
-  fontAg: '22_regular_170',
-  whiteSpace: 'pre-line',
-
-  a: {
-    textDecoration: 'underline',
+  '&:hover': {
+    color: '$white100',
   },
 
   '@tablet': {
-    fontAg: '16_medium_150',
-  },
-});
-
-const STarget = styled(SDescription, {
-  mb: '$24',
-
-  '@tablet': {
-    mb: '$20',
+    fontStyle: 'T3',
+    pb: '$6',
+    mr: '$12',
   },
 
-  span: {
-    fontAg: '22_semibold_150',
-
-    '@tablet': {
-      fontAg: '16_bold_150',
+  // 선택된 값 관련 수정 필요
+  variants: {
+    isSelected: {
+      true: {
+        color: '$white100',
+        borderBottom: `2px solid $white100`,
+      },
+      false: {
+        color: '$gray100',
+      },
     },
   },
 });

--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -8,10 +8,12 @@ import Loader from '@components/loader/Loader';
 import InformationPanel from '@components/page/meetingDetail/InformationPanel';
 import { Tab } from '@headlessui/react';
 import FeedPanel from '@components/page/meetingDetail/FeedPanel';
+import { Fragment, useState } from 'react';
 
 const DetailPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const { data: detailData } = useQueryGetMeeting({ params: { id } });
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
@@ -28,14 +30,14 @@ const DetailPage = () => {
         mutateMeetingDeletion={mutateDeleteMeeting}
         mutateApplication={mutatePostApplication}
       />
-      <Tab.Group
-        onChange={index => {
-          console.log('Changed selected tab to:', index);
-        }}
-      >
+      <Tab.Group selectedIndex={selectedIndex} onChange={index => setSelectedIndex(index)}>
         <STabList>
-          <STab>피드</STab>
-          <STab>모임 안내</STab>
+          <Tab as={Fragment}>
+            <STabButton isSelected={selectedIndex === 0}>피드</STabButton>
+          </Tab>
+          <Tab as={Fragment}>
+            <STabButton isSelected={selectedIndex === 1}>모임 안내</STabButton>
+          </Tab>
         </STabList>
         <Tab.Panels>
           <Tab.Panel>
@@ -62,14 +64,22 @@ const SDetailPage = styled(Box, {
 
 const STabList = styled(Box, {
   display: 'flex',
+
+  '@tablet': {
+    width: 'calc(100% + 40px)',
+    marginLeft: '-20px',
+  },
+
+  '@mobile': {
+    width: 'calc(100% + 32px)',
+    marginLeft: '-16px',
+  },
 });
 
-const STab = styled(Tab, {
-  pb: '$16',
-  mr: '$20',
+const STabButton = styled('button', {
+  pb: '$24',
+  mr: '$32',
   fontStyle: 'H1',
-  flex: '1',
-  textAlign: 'center',
   color: '$gray100',
 
   '&:hover': {
@@ -78,16 +88,20 @@ const STab = styled(Tab, {
 
   '@tablet': {
     fontStyle: 'T3',
-    pb: '$6',
-    mr: '$12',
+    padding: '$16 0',
+    mr: '$0',
+    flex: '1',
+    textAlign: 'center',
   },
 
-  // 선택된 값 관련 수정 필요
   variants: {
     isSelected: {
       true: {
         color: '$white100',
-        borderBottom: `2px solid $white100`,
+        borderBottom: `4px solid $white100`,
+        '@tablet': {
+          borderWidth: '2px',
+        },
       },
       false: {
         color: '$gray100',

--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -12,10 +12,12 @@ import 'dayjs/locale/ko';
 dayjs.locale('ko');
 import { PART_NAME } from '@constants/option';
 import { parseTextToLink } from '@components/util/parseTextToLink';
+import { useDisplay } from '@hooks/useDisplay';
 
 const DetailPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
+  const { isMobile } = useDisplay();
   const { data: detailData } = useQueryGetMeeting({ params: { id } });
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
@@ -79,16 +81,18 @@ const DetailPage = () => {
         mutateMeetingDeletion={mutateDeleteMeeting}
         mutateApplication={mutatePostApplication}
       />
-      <TabList text={selectedTab} size="small" onChange={handleChange}>
-        {detailList.map(
-          ({ id, title, content }) =>
-            content && (
-              <TabList.Item key={id} text={title}>
-                {title}
-              </TabList.Item>
-            )
-        )}
-      </TabList>
+      {isMobile && (
+        <TabList text={selectedTab} size="small" onChange={handleChange}>
+          {detailList.map(
+            ({ id, title, content }) =>
+              content && (
+                <TabList.Item key={id} text={title}>
+                  {title}
+                </TabList.Item>
+              )
+          )}
+        </TabList>
+      )}
       {detailList.map(
         ({ id, title, generation, partList, content }) =>
           content && (

--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -10,7 +10,7 @@ import { Tab } from '@headlessui/react';
 import FeedPanel from '@components/page/meetingDetail/FeedPanel';
 import { Fragment, useState } from 'react';
 
-const enum SelectedContent {
+const enum SelectedTab {
   FEED,
   INFORMATION,
 }
@@ -18,7 +18,7 @@ const enum SelectedContent {
 const DetailPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
-  const [selectedIndex, setSelectedIndex] = useState(SelectedContent.FEED);
+  const [selectedIndex, setSelectedIndex] = useState(SelectedTab.FEED);
   const { data: detailData } = useQueryGetMeeting({ params: { id } });
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
@@ -38,10 +38,10 @@ const DetailPage = () => {
       <Tab.Group selectedIndex={selectedIndex} onChange={index => setSelectedIndex(index)}>
         <STabList>
           <Tab as={Fragment}>
-            <STabButton isSelected={selectedIndex === SelectedContent.FEED}>피드</STabButton>
+            <STabButton isSelected={selectedIndex === SelectedTab.FEED}>피드</STabButton>
           </Tab>
           <Tab as={Fragment}>
-            <STabButton isSelected={selectedIndex === SelectedContent.INFORMATION}>모임 안내</STabButton>
+            <STabButton isSelected={selectedIndex === SelectedTab.INFORMATION}>모임 안내</STabButton>
           </Tab>
         </STabList>
         <Tab.Panels>

--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -10,10 +10,15 @@ import { Tab } from '@headlessui/react';
 import FeedPanel from '@components/page/meetingDetail/FeedPanel';
 import { Fragment, useState } from 'react';
 
+const enum SelectedContent {
+  FEED,
+  INFORMATION,
+}
+
 const DetailPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(SelectedContent.FEED);
   const { data: detailData } = useQueryGetMeeting({ params: { id } });
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
@@ -33,10 +38,10 @@ const DetailPage = () => {
       <Tab.Group selectedIndex={selectedIndex} onChange={index => setSelectedIndex(index)}>
         <STabList>
           <Tab as={Fragment}>
-            <STabButton isSelected={selectedIndex === 0}>피드</STabButton>
+            <STabButton isSelected={selectedIndex === SelectedContent.FEED}>피드</STabButton>
           </Tab>
           <Tab as={Fragment}>
-            <STabButton isSelected={selectedIndex === 1}>모임 안내</STabButton>
+            <STabButton isSelected={selectedIndex === SelectedContent.INFORMATION}>모임 안내</STabButton>
           </Tab>
         </STabList>
         <Tab.Panels>
@@ -105,6 +110,10 @@ const STabButton = styled('button', {
       },
       false: {
         color: '$gray100',
+        paddingBottom: '$28',
+        '@tablet': {
+          paddingBottom: '$18',
+        },
       },
     },
   },

--- a/src/components/page/meetingDetail/Carousel.tsx
+++ b/src/components/page/meetingDetail/Carousel.tsx
@@ -53,6 +53,11 @@ const SCarousel = styled(Box, {
       marginLeft: '-20px',
       display: 'block',
     },
+
+    '@mobile': {
+      width: 'calc(100% + 32px)',
+      marginLeft: '-16px',
+    },
   },
 
   '.slick-list': {

--- a/src/components/page/meetingDetail/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/FeedPanel.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const FeedPanel = () => {
+  return <div>피드</div>;
+};
+
+export default FeedPanel;

--- a/src/components/page/meetingDetail/InformationPanel.tsx
+++ b/src/components/page/meetingDetail/InformationPanel.tsx
@@ -1,0 +1,150 @@
+import { TabList } from '@components/tabList/TabList';
+import { styled } from 'stitches.config';
+import { useDisplay } from '@hooks/useDisplay';
+import { parseTextToLink } from '@components/util/parseTextToLink';
+import dayjs from 'dayjs';
+import 'dayjs/locale/ko';
+dayjs.locale('ko');
+import { PART_NAME } from '@constants/option';
+import { useRef, useState } from 'react';
+import { MeetingResponse } from '@api/meeting';
+import { Box } from '@components/box/Box';
+
+interface InformationPanelProps {
+  detailData: MeetingResponse;
+}
+
+const InformationPanel = ({ detailData }: InformationPanelProps) => {
+  const { isMobile } = useDisplay();
+  const tabRef = useRef<HTMLElement[]>([]);
+  const detailList = [
+    {
+      id: 0,
+      title: '모임 소개',
+      content: detailData?.desc,
+    },
+    {
+      id: 1,
+      title: '활동 기간',
+      content: `${dayjs(detailData?.mStartDate ?? '').format('YYYY.MM.DD (ddd)')} ~ ${dayjs(
+        detailData?.mEndDate ?? ''
+      ).format('YYYY.MM.DD (ddd)')}`,
+    },
+    {
+      id: 2,
+      title: '진행 방식',
+      content: detailData?.processDesc,
+    },
+    {
+      id: 3,
+      title: '모집 대상',
+      generation: detailData?.canJoinOnlyActiveGeneration ? '활동 기수' : '전체',
+      partList: detailData?.joinableParts?.map(key => PART_NAME[key]),
+      content: detailData?.targetDesc,
+    },
+    {
+      id: 4,
+      title: '개설자 소개',
+      content: detailData?.leaderDesc,
+    },
+    {
+      id: 5,
+      title: '유의사항',
+      content: detailData?.note,
+    },
+  ];
+  const [selectedTab, setSelectedTab] = useState(detailList[0].title);
+
+  const handleChange = (text: string) => {
+    setSelectedTab(text);
+    tabRef.current[detailList.findIndex(item => item.title === text)].scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const handleContent = (content: string) => {
+    return parseTextToLink(content);
+  };
+
+  return (
+    <SInformationPanel>
+      {isMobile && (
+        <TabList text={selectedTab} size="small" onChange={handleChange}>
+          {detailList.map(
+            ({ id, title, content }) =>
+              content && (
+                <TabList.Item key={id} text={title}>
+                  {title}
+                </TabList.Item>
+              )
+          )}
+        </TabList>
+      )}
+      {detailList.map(
+        ({ id, title, generation, partList, content }) =>
+          content && (
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            <SDetail key={id} ref={element => (tabRef.current[id] = element!)}>
+              <STitle>{title}</STitle>
+              {title === '모집 대상' && (
+                <STarget>
+                  대상 기수 : {generation}
+                  <br />
+                  대상 파트 : {partList?.join(', ')}
+                </STarget>
+              )}
+              <SDescription>{handleContent(content)}</SDescription>
+            </SDetail>
+          )
+      )}
+    </SInformationPanel>
+  );
+};
+
+export default InformationPanel;
+
+const SInformationPanel = styled(Box, {
+  '@tablet': {
+    mt: '$8',
+  },
+});
+
+const SDetail = styled('section', {
+  scrollMarginTop: '$80',
+  color: '$white100',
+  mt: '$120',
+
+  '@tablet': {
+    mt: '$56',
+  },
+});
+
+const STitle = styled('h2', {
+  fontAg: '24_bold_100',
+  mb: '$24',
+
+  '@tablet': {
+    fontStyle: 'H4',
+    mb: '$20',
+  },
+});
+
+const SDescription = styled('p', {
+  fontAg: '22_regular_170',
+  whiteSpace: 'pre-line',
+
+  a: {
+    textDecoration: 'underline',
+  },
+
+  '@tablet': {
+    fontStyle: 'B3',
+    color: '$gray40',
+  },
+});
+
+const STarget = styled(SDescription, {
+  mb: '$24',
+
+  '@tablet': {
+    mb: '$20',
+  },
+});

--- a/src/components/tabList/TabList.tsx
+++ b/src/components/tabList/TabList.tsx
@@ -74,8 +74,8 @@ const STab = styled('li', {
 
         '@tablet': {
           fontAg: '16_bold_100',
-          paddingBottom: '$10',
-          mr: '$16',
+          padding: '$16 $8',
+          mr: '$8',
           minWidth: 'fit-content',
 
           '&:last-child': {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #345 

## 📋 작업 내용
- [x] 모임 상세 페이지에 피드, 모임 안내 탭 추가

## 📌 PR Point
- 기존에는 `pages/detail/index.tsx`에 모임 안내 내용이 들어갔는데,
  피드 탭과 모임 안내 탭이 각각 생기면서
  피드 내용은 `src/components/page/meetingDetail/FeedPanel.tsx`로
  모임 안내 내용은 `src/components/page/meetingDetail/InformationPanel.tsx`로 분리했습니다.

## 📸 스크린샷
|데스크탑|모바일|
|:-:|:-:|
|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/be8de148-bff6-4458-849d-436c0bf70208)|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/133bd0c8-2897-4039-a8d9-e1c958e5a021)|