### PR TITLE
피드 상세 content 부분 모바일 대응

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -24,6 +24,10 @@ const SContainer = styled('div', {
   borderRadius: '50%',
   overflow: 'hidden',
   flexType: 'center',
+  '@tablet': {
+    width: '40px',
+    height: '40px',
+  },
 });
 const SImage = styled('img', {
   width: '100%',

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -5,12 +5,13 @@ interface AvatarProps {
   src: string;
   alt: string;
   sx?: CSSProperties;
+  className?: string;
   Overlay?: React.ReactNode;
 }
 
-export default function Avatar({ src, alt, sx, Overlay }: AvatarProps) {
+export default function Avatar({ src, alt, sx, className, Overlay }: AvatarProps) {
   return (
-    <SContainer style={sx}>
+    <SContainer style={sx} className={className}>
       {Overlay}
       <SImage src={src} alt={alt} />
     </SContainer>
@@ -24,10 +25,6 @@ const SContainer = styled('div', {
   borderRadius: '50%',
   overflow: 'hidden',
   flexType: 'center',
-  '@tablet': {
-    width: '40px',
-    height: '40px',
-  },
 });
 const SImage = styled('img', {
   width: '100%',

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -20,7 +20,7 @@ export default function FeedPostViewer({ post, Actions }: FeedPostViewerProps) {
       <ContentWrapper>
         <ContentHeader>
           <AuthorWrapper>
-            <Avatar src={post.user.profileImage || ''} alt={post.user.name} />
+            <SAvatar src={post.user.profileImage || ''} alt={post.user.name} />
             <AuthorInfo>
               <AuthorName>{post.user.name}</AuthorName>
               <UpdatedDate>{post.updatedDate}</UpdatedDate>
@@ -217,4 +217,10 @@ const CommentInput = styled('input', {
 const SendButton = styled('button', {
   width: '32px',
   height: '32px',
+});
+const SAvatar = styled(Avatar, {
+  '@tablet': {
+    width: '40px',
+    height: '40px',
+  },
 });

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -144,6 +144,7 @@ const ViewCount = styled('span', {
   fontStyle: 'B4',
   '@tablet': {
     mr: '$0',
+    fontStyle: 'C1',
   },
 });
 const MenuItems = styled(Menu.Items, {

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -90,7 +90,7 @@ const ContentWrapper = styled('div', {
   flexDirection: 'column',
   gap: '20px',
   '@tablet': {
-    padding: '0px',
+    padding: '12px 16px 20px 16px',
   },
 });
 const ContentHeader = styled('div', {
@@ -124,18 +124,27 @@ const ContentBody = styled('div', {
 const Title = styled('h2', {
   color: 'white',
   fontStyle: 'H2',
+  '@tablet': {
+    fontStyle: 'H4',
+  },
 });
 const Contents = styled('p', {
   mt: '$12',
   color: '$gray30',
   fontStyle: 'B2',
+  '@tablet': {
+    fontStyle: 'B3',
+  },
 });
 const ViewCount = styled('span', {
   mt: '$16',
-  marginRight: '20px', // TODO: design 체크 필요
+  mr: '$16', // TODO: design 체크 필요 > 체크 완료
   alignSelf: 'flex-end',
   color: '$gray100',
   fontStyle: 'B4',
+  '@tablet': {
+    mr: '$0',
+  },
 });
 const MenuItems = styled(Menu.Items, {
   position: 'absolute',

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -79,12 +79,19 @@ const Container = styled(Box, {
   borderRadius: '20px',
   border: '1px solid $black60',
   background: '$black100',
+  '@tablet': {
+    width: '360px',
+    border: 'none',
+  },
 });
 const ContentWrapper = styled('div', {
   padding: '36px 24px 28px 40px',
   display: 'flex',
   flexDirection: 'column',
   gap: '20px',
+  '@tablet': {
+    padding: '0px',
+  },
 });
 const ContentHeader = styled('div', {
   display: 'flex',

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -170,7 +170,6 @@ const MenuItem = styled('button', {
     borderTop: 'none',
   },
 });
-
 const CommentLikeWrapper = styled('div', {
   color: '$gray08',
   fontStyle: 'T5',
@@ -179,14 +178,15 @@ const CommentLikeWrapper = styled('div', {
   borderTop: '1px solid $black60',
   borderBottom: '1px solid $black60',
 });
-
 const Divider = styled('div', {
   background: '$black60',
   width: '1px',
   height: '24px',
   margin: '12px 159px 12px 171px',
+  '@tablet': {
+    margin: '12px 54px 12px 60px',
+  },
 });
-
 const CommentLike = styled('div', {
   color: '$gray80',
   fontStyle: 'T5',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #394 

## 📋 작업 내용
- [x] 피드 상세의 content 부분 모바일 대응

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
- @tablet 을 이용해서 모바일뷰 대응했습니다!
- 어떤 위험이나 우려가 발견되었는지
- 어떤 부분에 리뷰어가 집중해야 하는지
- 개발하면서 어떤 점이 궁금했는지

## 📸 스크린샷
<img width="521" alt="image" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/86764406/a3922be1-64c1-49b5-a0e2-8a865d259e03">

