### PR TITLE
SVG 크기 설정을 위한 next.config.js 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,27 @@ const nextConfig = {
           },
         },
         {
+          resourceQuery: /v2/, // *.svg?v2
+          use: {
+            loader: '@svgr/webpack',
+            options: {
+              svgo: true,
+              svgoConfig: {
+                plugins: [
+                  {
+                    name: 'preset-default',
+                    params: {
+                      overrides: {
+                        removeViewBox: false,
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+        {
           use: '@svgr/webpack',
         },
       ],

--- a/src/types/svg.d.ts
+++ b/src/types/svg.d.ts
@@ -14,3 +14,11 @@ declare module '*.svg?rect' {
   const src: string;
   export default ReactComponent;
 }
+
+declare module '*.svg?v2' {
+  import React = require('react');
+
+  export const ReactComponent: REact.FC<React.SVGProps<SVGSVGElement>>;
+  const src: string;
+  export default ReactComponent;
+}


### PR DESCRIPTION
## 📋 작업 내용
- [x] SVG 컴포넌트 크기 설정이 안돼서 설정 가능하도록 next.config.js 설정을 수정했어요. `icon.svg?v2` 라는 쿼리 스트링을 import 할때 붙이면 해당 파일을 import 할때는 webpack이 svgo를 사용하도록 하고, viewBox 옵션을 제거하지 않도록 했어요(svgo의 default 동작은 viewBox를 제거해요)

## 📌 PR Point
이렇게 해서 크기를 수정할 수 있어요
### Inline Attributes
```tsx
import CheckedIconV2 from '@assets/svg/icon_progress_checked.svg?v2';
const Foo = () => <CheckedIconV2 width={24} height={24} />;
```

### CSS
```tsx
import CheckedIconV2 from '@assets/svg/icon_progress_checked.svg?v2';

const ScalableCheckedIconV2 = styled(CheckedIconV2, {
  width: '24px',
  height: '24px',
});

const Foo = () => <ScalableCheckedIconV2 />;
```