### PR TITLE
피드 상세 뷰 이미지 영역 추가

### DIFF
--- a/src/components/feed/FeedPostViewer/FeedPostViewer.stories.ts
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.stories.ts
@@ -20,7 +20,7 @@ export const Default: Story = {
       title: '하트시그널 시즌 1부터 시즌 4까지 중에 가장 인기가 많았던 출연자는?',
       contents: `1번 김현우\n2번 오영주\n3번 임현주\n4번 박지현\n5번 기타`,
       updatedDate: '2시간 전',
-      images: [],
+      images: ['https://via.placeholder.com/600/92c952'],
       user: {
         id: 1,
         name: '김지민',

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -139,7 +139,7 @@ const Contents = styled('p', {
 const ImageSection = styled('section', {
   paddingRight: '25px',
   marginTop: '20px',
-  marginBottom: '12px 12px 12px 12px',
+  marginBottom: '12px',
 });
 const BigImage = styled('img', {
   width: '100%',

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -42,6 +42,19 @@ export default function FeedPostViewer({ post, Actions }: FeedPostViewerProps) {
         <ContentBody>
           <Title>{post.title}</Title>
           <Contents>{post.contents}</Contents>
+          {post.images && (
+            <ImageSection>
+              {post.images.length === 1 ? (
+                <BigImage src={post.images[0]} />
+              ) : (
+                <ImageListWrapper>
+                  {post.images.map((image, index) => (
+                    <ImageListItem key={index} src={image} />
+                  ))}
+                </ImageListWrapper>
+              )}
+            </ImageSection>
+          )}
           <ViewCount>조회 {post.viewCount}회</ViewCount>
         </ContentBody>
       </ContentWrapper>
@@ -122,6 +135,28 @@ const Contents = styled('p', {
   mt: '$12',
   color: '$gray30',
   fontStyle: 'B2',
+});
+const ImageSection = styled('section', {
+  paddingRight: '25px',
+  marginTop: '20px',
+  marginBottom: '12px 12px 12px 12px',
+});
+const BigImage = styled('img', {
+  width: '100%',
+  height: '453px',
+  objectFit: 'cover',
+  borderRadius: '10px',
+});
+const ImageListWrapper = styled('div', {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(5, 1fr)',
+  gap: '8px',
+});
+const ImageListItem = styled('img', {
+  width: '100%',
+  height: '136px',
+  objectFit: 'cover',
+  borderRadius: '8px',
 });
 const ViewCount = styled('span', {
   mt: '$16',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #404 

## 📋 작업 내용
- [x] 피드 상세 뷰 내에 이미지 영역을 추가했어요

## 📸 스크린샷
### 사진 1개
<img width="1283" alt="Screenshot 2023-09-16 at 10 24 16 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/9af209be-c082-40c5-a92e-77f8810f0112">

### 사진 여러개
<img width="1303" alt="Screenshot 2023-09-16 at 10 24 02 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/8e0a4a9d-68c9-4599-9c4d-905892dac806">
