### PR TITLE
피드 상세 뷰 이미지 영역 및 캐러셀 반응형 디자인 추가

### DIFF
--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -164,6 +164,9 @@ const ImageSection = styled('section', {
   paddingRight: '25px',
   marginTop: '20px',
   marginBottom: '12px',
+  '@tablet': {
+    paddingRight: 0,
+  },
 });
 const BigImage = styled('img', {
   width: '100%',
@@ -171,6 +174,9 @@ const BigImage = styled('img', {
   objectFit: 'cover',
   borderRadius: '10px',
   cursor: 'pointer',
+  '@tablet': {
+    height: '219px',
+  },
 });
 const ImageListWrapper = styled('div', {
   display: 'grid',

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -182,6 +182,11 @@ const ImageListWrapper = styled('div', {
   display: 'grid',
   gridTemplateColumns: 'repeat(5, 1fr)',
   gap: '8px',
+  '@tablet': {
+    display: 'flex',
+    overflow: 'scroll',
+    gap: '6px',
+  },
 });
 const ImageListItem = styled('img', {
   width: '100%',
@@ -189,6 +194,9 @@ const ImageListItem = styled('img', {
   objectFit: 'cover',
   borderRadius: '8px',
   cursor: 'pointer',
+  '@tablet': {
+    height: '144px',
+  },
 });
 const ViewCount = styled('span', {
   mt: '$16',

--- a/src/components/modal/ImageCarouselModal.tsx
+++ b/src/components/modal/ImageCarouselModal.tsx
@@ -33,7 +33,7 @@ export default function ImageCarouselModal({ isOpen, close, images, startIndex =
         <Container>
           {/* top 고정 요소 */}
           {/* eslint-disable-next-line prettier/prettier */}
-          <Counter>{currentIndex}/{images.length}</Counter>
+          <Counter>{currentIndex} / {images.length}</Counter>
           <CloseButton onClick={close}>
             <CloseIcon />
           </CloseButton>
@@ -83,6 +83,12 @@ const Counter = styled('div', {
   left: '48px',
   color: 'white',
   fontStyle: 'T1',
+  '@tablet': {
+    top: '8px',
+    left: '16px',
+    fontStyle: 'H3',
+    lineHeight: '28px',
+  },
 });
 const CloseButton = styled('button', {
   position: 'absolute',
@@ -92,6 +98,10 @@ const CloseButton = styled('button', {
   height: '24px',
   border: 'none',
   outline: 'none',
+  '@tablet': {
+    top: '10px',
+    right: '13px',
+  },
 });
 const CarouselContainer = styled('div', {
   overflow: 'hidden',
@@ -121,4 +131,7 @@ const ArrowButton = styled('button', {
   flexShrink: 0,
   borderRadius: '20px',
   background: '$black80',
+  '@tablet': {
+    display: 'none',
+  },
 });


### PR DESCRIPTION
## 🚩 관련 이슈
- close #415 

## 📋 작업 내용
- [x] 피드 상세 뷰 이미지 영역 및 캐러셀 모달 반응형 디자인을 적용했어요

## 📸 스크린샷
<img width="549" alt="Screenshot 2023-09-17 at 3 32 56 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/57a242be-a4da-4d54-b830-b3ca743ea30f">
<img width="549" alt="Screenshot 2023-09-17 at 3 33 18 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/847d4ec9-1ebb-4f65-875a-d00558f82f16">
<img width="551" alt="Screenshot 2023-09-17 at 3 33 28 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/d21e9bb7-e512-491a-9401-c95e027d88ac">
