### PR TITLE
피드 상세 뷰 게시글 조회 API 연동

### DIFF
--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -1,0 +1,29 @@
+import { paths } from '@/__generated__/schema';
+import { apiV2 } from '@api/index';
+import FeedPostViewer from '@components/feed/FeedPostViewer/FeedPostViewer';
+import Loader from '@components/loader/Loader';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+
+export default function PostPage() {
+  const { query } = useRouter();
+  const data = useQuery({
+    queryFn: () => apiV2.GET('/post/v1/{postId}', { params: { path: { postId: Number(query.id as string) } } }),
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    select: res => res.data.data,
+    enabled: !!query.id,
+  });
+
+  // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요
+  const post = data.data as paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
+
+  // TODO: loading 스켈레톤 UI가 있으면 좋을 듯
+  if (!post) return <Loader />;
+
+  return (
+    <div>
+      <FeedPostViewer post={post} Actions={['수정', '삭제']} />
+    </div>
+  );
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #417 

## 📋 작업 내용
- [x] 피드 상세 조회 페이지 추가(`/group/post?id={postId}`
- [x] 피드 상세 조회 페이지에 게시글 조회 API 연동

## 📸 스크린샷
<img width="915" alt="Screenshot 2023-09-17 at 4 39 09 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/599b179e-e625-41e9-8642-738aac69875e">
