### PR TITLE
피드 상세 뷰 게시글 작성 시간 포맷 수정

### DIFF
--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -10,6 +10,11 @@ import { styled } from 'stitches.config';
 import { Box } from '@components/box/Box';
 import { useOverlay } from '@hooks/useOverlay/Index';
 import ImageCarouselModal from '@components/modal/ImageCarouselModal';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/ko';
+dayjs.extend(relativeTime);
+dayjs.locale('ko');
 
 interface FeedPostViewerProps {
   post: paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
@@ -33,7 +38,7 @@ export default function FeedPostViewer({ post, Actions }: FeedPostViewerProps) {
             <SAvatar src={post.user.profileImage || ''} alt={post.user.name} />
             <AuthorInfo>
               <AuthorName>{post.user.name}</AuthorName>
-              <UpdatedDate>{post.updatedDate}</UpdatedDate>
+              <UpdatedDate>{dayjs(post.updatedDate).fromNow()}</UpdatedDate>
             </AuthorInfo>
           </AuthorWrapper>
           <Menu as="div" style={{ position: 'relative' }}>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #421 

## 📋 작업 내용
- [x] 피드 상세 뷰 게시글 작성 시간을 포맷에 맞게 수정

## 📸 스크린샷
<img width="167" alt="Screenshot 2023-09-17 at 5 31 25 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/d559114e-8cac-4062-b0bb-1b9bb913f5b3">

