### PR TITLE
모임 피드 아이템 보완

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,8 +1,9 @@
 import { CSSProperties } from 'react';
 import { styled } from 'stitches.config';
+import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
 
 interface AvatarProps {
-  src: string;
+  src?: string;
   alt: string;
   sx?: CSSProperties;
   className?: string;
@@ -13,7 +14,7 @@ export default function Avatar({ src, alt, sx, className, Overlay }: AvatarProps
   return (
     <SContainer style={sx} className={className}>
       {Overlay}
-      <SImage src={src} alt={alt} />
+      {src ? <SImage src={src} alt={alt} /> : <ProfileDefaultIcon />}
     </SContainer>
   );
 }

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -2,7 +2,7 @@ import AvatarGroup from '@components/avatar/AvatarGroup';
 import { Box } from '@components/box/Box';
 import { Flex } from '@components/util/layout/Flex';
 import { styled } from 'stitches.config';
-import MoreIcon from '@assets/svg/more.svg';
+// import MoreIcon from '@assets/svg/more.svg';
 import LikeDefaultIcon from '@assets/svg/like_default.svg';
 import LikeActiveIcon from '@assets/svg/like_active.svg';
 import Avatar from '@components/avatar/Avatar';
@@ -49,7 +49,7 @@ const FeedItem = ({
           <SName>{name}</SName>
           <STime>{dayjs(updatedDate).fromNow()}</STime>
         </Flex>
-        <MoreIcon />
+        {/* <MoreIcon /> */}
       </STop>
 
       <STitle>{title}</STitle>

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -10,7 +10,6 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import 'dayjs/locale/ko';
 import { useState } from 'react';
-import { colors } from '@sopt-makers/colors';
 import truncateText from '@utils/truncateText';
 
 dayjs.extend(relativeTime);
@@ -173,9 +172,9 @@ const SThumbnailCount = styled(Box, {
   top: '12px',
   right: '12px',
   zIndex: 1,
-  backgroundColor: colors.black100,
+  backgroundColor: '$black100',
   opacity: 0.6,
-  color: colors.gray30,
+  color: '$gray30',
   borderRadius: '50%',
   fontStyle: 'T5',
   width: '40px',
@@ -237,7 +236,7 @@ const SLikeButton = styled('button', {
 
 const SOverlay = styled(Box, {
   position: 'absolute',
-  background: colors.black100,
+  background: '$black100',
   opacity: 0.7,
   width: '100%',
   height: '100%',

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -10,6 +10,7 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import 'dayjs/locale/ko';
 import { useState } from 'react';
+import { colors } from '@sopt-makers/colors';
 
 dayjs.extend(relativeTime);
 dayjs.locale('ko');
@@ -59,8 +60,13 @@ const FeedItem = ({
         <Flex align="center">
           {commenterThumbnails && (
             <AvatarGroup>
-              {commenterThumbnails.map(thumbnail => (
-                <Avatar key={thumbnail} src={thumbnail} alt="" />
+              {commenterThumbnails.slice(0, 3).map((thumbnail, index) => (
+                <Avatar
+                  key={`${thumbnail}-${index}`}
+                  src={thumbnail}
+                  alt=""
+                  Overlay={commenterThumbnails.length > 3 && index === 2 && <SOverlay>+</SOverlay>}
+                />
               ))}
             </AvatarGroup>
           )}
@@ -197,4 +203,13 @@ const SLikeButton = styled('button', {
   '& > svg': {
     mr: '$6',
   },
+});
+
+const SOverlay = styled(Box, {
+  position: 'absolute',
+  background: colors.black100,
+  opacity: 0.7,
+  width: '100%',
+  height: '100%',
+  flexType: 'center',
 });

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -11,6 +11,8 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import 'dayjs/locale/ko';
 import { useState } from 'react';
 import truncateText from '@utils/truncateText';
+import { THUMBNAIL_IMAGE_INDEX } from '@constants/index';
+import { AVATAR_MAX_LENGTH, CARD_CONTENT_MAX_LENGTH, CARD_TITLE_MAX_LENGTH, LIKE_MAX_COUNT } from '@constants/feed';
 
 dayjs.extend(relativeTime);
 dayjs.locale('ko');
@@ -38,7 +40,7 @@ const FeedItem = ({
   commentCount,
   likeCount,
 }: FeedItemProps) => {
-  const formattedLikeCount = likeCount > 999 ? '999+' : likeCount;
+  const formattedLikeCount = likeCount > LIKE_MAX_COUNT ? `${LIKE_MAX_COUNT}+` : likeCount;
   const [like, setLike] = useState(false);
 
   return (
@@ -52,11 +54,11 @@ const FeedItem = ({
         {/* <MoreIcon /> */}
       </STop>
 
-      <STitle>{truncateText(title, 40)}</STitle>
-      <SContent>{truncateText(contents, 70)}</SContent>
+      <STitle>{truncateText(title, CARD_TITLE_MAX_LENGTH)}</STitle>
+      <SContent>{truncateText(contents, CARD_CONTENT_MAX_LENGTH)}</SContent>
       {images && (
         <SThumbnailWrapper>
-          <SThumbnail src={images[0]} alt="" />
+          <SThumbnail src={images[THUMBNAIL_IMAGE_INDEX]} alt="" />
           {images.length > 1 && <SThumbnailCount>+{images.length - 1}</SThumbnailCount>}
         </SThumbnailWrapper>
       )}
@@ -65,12 +67,15 @@ const FeedItem = ({
         <Flex align="center">
           {commenterThumbnails && (
             <AvatarGroup>
-              {commenterThumbnails.slice(0, 3).map((thumbnail, index) => (
+              {commenterThumbnails.slice(0, AVATAR_MAX_LENGTH).map((thumbnail, index) => (
                 <Avatar
                   key={`${thumbnail}-${index}`}
                   src={thumbnail}
                   alt=""
-                  Overlay={commenterThumbnails.length > 3 && index === 2 && <SOverlay>+</SOverlay>}
+                  Overlay={
+                    commenterThumbnails.length > AVATAR_MAX_LENGTH &&
+                    index === AVATAR_MAX_LENGTH - 1 && <SOverlay>+</SOverlay>
+                  }
                 />
               ))}
             </AvatarGroup>

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -55,7 +55,12 @@ const FeedItem = ({
 
       <STitle>{truncateText(title, 40)}</STitle>
       <SContent>{truncateText(contents, 70)}</SContent>
-      {images && <SThumbnail src={images[0]} alt="" />}
+      {images && (
+        <SThumbnailWrapper>
+          <SThumbnail src={images[0]} alt="" />
+          {images.length > 1 && <SThumbnailCount>+{images.length - 1}</SThumbnailCount>}
+        </SThumbnailWrapper>
+      )}
 
       <SBottom>
         <Flex align="center">
@@ -145,6 +150,10 @@ const SContent = styled(Box, {
   },
 });
 
+const SThumbnailWrapper = styled(Box, {
+  position: 'relative',
+});
+
 const SThumbnail = styled('img', {
   display: 'block',
   mb: '$20',
@@ -156,6 +165,26 @@ const SThumbnail = styled('img', {
 
   '@tablet': {
     maxWidth: '100%',
+  },
+});
+
+const SThumbnailCount = styled(Box, {
+  position: 'absolute',
+  top: '12px',
+  right: '12px',
+  zIndex: 1,
+  backgroundColor: colors.black100,
+  opacity: 0.6,
+  color: colors.gray30,
+  borderRadius: '50%',
+  fontStyle: 'T5',
+  width: '40px',
+  height: '40px',
+  flexType: 'center',
+
+  '@tablet': {
+    width: '36px',
+    height: '36px',
   },
 });
 

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -11,6 +11,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import 'dayjs/locale/ko';
 import { useState } from 'react';
 import { colors } from '@sopt-makers/colors';
+import truncateText from '@utils/truncateText';
 
 dayjs.extend(relativeTime);
 dayjs.locale('ko');
@@ -52,8 +53,8 @@ const FeedItem = ({
         {/* <MoreIcon /> */}
       </STop>
 
-      <STitle>{title}</STitle>
-      <SContent>{contents}</SContent>
+      <STitle>{truncateText(title, 40)}</STitle>
+      <SContent>{truncateText(contents, 70)}</SContent>
       {images && <SThumbnail src={images[0]} alt="" />}
 
       <SBottom>

--- a/src/constants/feed.ts
+++ b/src/constants/feed.ts
@@ -1,0 +1,4 @@
+export const LIKE_MAX_COUNT = 999;
+export const AVATAR_MAX_LENGTH = 3;
+export const CARD_TITLE_MAX_LENGTH = 40;
+export const CARD_CONTENT_MAX_LENGTH = 70;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const THUMBNAIL_IMAGE_INDEX = 0;

--- a/src/utils/truncateText.ts
+++ b/src/utils/truncateText.ts
@@ -1,0 +1,6 @@
+export default function truncateText(text: string, limit: number) {
+  if (text.length < limit) {
+    return text;
+  }
+  return `${text.slice(0, limit)}...`;
+}

--- a/stitches.config.ts
+++ b/stitches.config.ts
@@ -279,7 +279,7 @@ const stitches = createStitches({
       170: '170%',
       H1: '24px',
       H2: '30px',
-      H3: '18px',
+      H3: '28px',
       H4: '24px',
       H5: '14px',
       T1: '32px',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #411 

## 📋 작업 내용
- [x] 제목 말줄임 처리 (40자 초과 시)
- [x] 콘텐츠 말줄임 처리 (70자 초과 시)
- [x] 추가 이미지 개수 표시
- [x] 더보기 버튼 주석 처리
- [x] 댓글 부분에 [Overlay 인터페이스](https://github.com/sopt-makers/sopt-crew-frontend/pull/385) 반영

## 📌 PR Point
- 글자 수를 기준으로 말줄임 처리가 필요한 경우, utils에 있는 `truncateText`를 활용해 주세요 😉
- 프사가 없는 경우를 대비해 Avatar.tsx에 `<ProfileDefaultIcon />`을 추가했어요.
- 이번 릴리즈에는 수정/삭제 기능이 포함되지 않아 더보기 버튼을 숨겼어요.

## 📸 스크린샷
![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/c86618e3-fc27-41de-b35a-7b3eeeabd804)
