### PR TITLE
피드 작성 버튼 임시 제거 및 주석 처리

### DIFF
--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -22,7 +22,7 @@ const enum SelectedTab {
 const DetailPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
-  const [selectedIndex, setSelectedIndex] = useState(SelectedTab.FEED);
+  const [selectedIndex, setSelectedIndex] = useState(SelectedTab.INFORMATION);
   const { data: detailData } = useQueryGetMeeting({ params: { id } });
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
@@ -51,7 +51,8 @@ const DetailPage = () => {
           </STabList>
           <Tab.Panels>
             <Tab.Panel>
-              <FeedPanel isMember={detailData?.approved || detailData?.host} />
+              {/* <FeedPanel isMember={detailData?.approved || detailData?.host} /> */}
+              <FeedPanel />
             </Tab.Panel>
             <Tab.Panel>
               <InformationPanel detailData={detailData} />

--- a/src/components/page/meetingDetail/Feed/EmptyView.tsx
+++ b/src/components/page/meetingDetail/Feed/EmptyView.tsx
@@ -1,21 +1,21 @@
 import { Box } from '@components/box/Box';
 import { styled } from 'stitches.config';
 
-interface EmptyViewProps {
-  isMember: boolean;
-}
+// interface EmptyViewProps {
+//   isMember: boolean;
+// }
 
-const EmptyView = ({ isMember }: EmptyViewProps) => {
+const EmptyView = () => {
   return (
     <SContent>
       <p>아직 작성된 피드가 없어요.</p>
 
-      {isMember && (
+      {/* {isMember && (
         <>
           <p>첫번째 작성자가 되어볼까요?</p>
           <button>작성하러 가기</button>
         </>
-      )}
+      )} */}
     </SContent>
   );
 };

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { styled } from 'stitches.config';
 import EmptyView from './EmptyView';
 
-interface FeedPanelProps {
-  isMember: boolean;
-}
+// interface FeedPanelProps {
+//   isMember: boolean;
+// }
 
-const FeedPanel = ({ isMember }: FeedPanelProps) => {
+const FeedPanel = () => {
   return (
     <SContainer>
-      <EmptyView isMember={isMember} />
+      <EmptyView />
     </SContainer>
   );
 };


### PR DESCRIPTION
## 📌 PR Point
- 프로덕션 배포를 위해 버튼을 잠시 없애고, 모임 안내 탭을 기본으로 설정했어요.

![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/d6e1a862-e0ef-4bdb-be01-8cdefa545a56)