### PR TITLE
제목 minHeight 설정

### DIFF
--- a/src/components/page/meetingList/Card/MobileSize/CardType.tsx
+++ b/src/components/page/meetingList/Card/MobileSize/CardType.tsx
@@ -81,6 +81,7 @@ const STitle = styled('p', {
   '@tablet': {
     fontAg: '14_semibold_140',
     maxWidth: '162px',
+    minHeight: '40px',
   },
 });
 


### PR DESCRIPTION
## 📌 PR Point
- 아래 스크린샷처럼 카드가 밀려 보이지 않도록 title에 minHeight를 설정했어요.
<img src="https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/917933a1-9578-47b3-a341-503e3d0fa6fe" width="300" />
