### PR TITLE
인증토큰 적용 방법 수정 및 opanapi-fetch 가 codegen 한 api 클라이언트에 인증 토큰 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.3",
     "@hookform/resolvers": "^2.9.10",
+    "@nanostores/react": "^0.7.1",
     "@sentry/nextjs": "^7.51.0",
     "@sopt-makers/colors": "^1.0.0",
     "@sopt-makers/playground-common": "^1.2.2",
@@ -26,6 +27,7 @@
     "dayjs": "^1.11.6",
     "embla-carousel-react": "^8.0.0-rc13",
     "nanoid": "^4.0.0",
+    "nanostores": "^0.9.3",
     "next": "12.3.1",
     "openapi-fetch": "^0.7.1",
     "react": "18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,7 @@
 import type { AppProps } from 'next/app';
 import Script from 'next/script';
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { theme } from 'stitches.config';
 import '../styles/globals.css';
@@ -11,15 +11,20 @@ import { GTM_ID, pageview } from '@utils/gtm';
 import { setAccessTokens } from '@components/util/auth';
 import Loader from '@components/loader/Loader';
 import ChannelService from '@utils/ChannelService';
-import { api, playgroundApi } from '@api/index';
 import { fetchMyProfile } from '@api/user';
 import { OverlayProvider } from '@hooks/useOverlay/OverlayProvider';
 import SEO from '@components/seo/SEO';
+import { crewToken, playgroundToken } from '@/stores/tokenStore';
+import { useStore } from '@nanostores/react';
+
+setAccessTokens();
 
 function MyApp({ Component, pageProps }: AppProps) {
   const [queryClient] = React.useState(() => new QueryClient());
   const router = useRouter();
-  const [isServiceReady, setIsServiceReady] = useState(false);
+  const _crewToken = useStore(crewToken);
+  const _playgroundToken = useStore(playgroundToken);
+  const isServiceReady = _crewToken && _playgroundToken;
 
   useEffect(() => {
     router.events.on('routeChangeComplete', pageview);
@@ -27,20 +32,6 @@ function MyApp({ Component, pageProps }: AppProps) {
       router.events.off('routeChangeComplete', pageview);
     };
   }, [router.events]);
-
-  useEffect(() => {
-    // NOTE: development 환경에서는 테스트 토큰을 사용한다.
-    if (process.env.NODE_ENV === 'development') {
-      api.defaults.headers.common['Authorization'] =
-        'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoi7J207J6s7ZuIIiwiaWQiOjI1NywiaWF0IjoxNjgxODE5NTcxLCJleHAiOjE3MTc4MTk1NzF9.JVG-xzOVikIbX7vj_cZig_TTHxM-EzMgjO-_VGRbLTs';
-      playgroundApi.defaults.headers.common['Authorization'] =
-        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMyIsImV4cCI6MTY4MjI0NzIzNn0.jPK_OTNXVNvnVFkbdme6tfABsdryUFgXEYOYGCAxdPc';
-      setIsServiceReady(true);
-      return;
-    }
-    // NOTE: NODE_ENV가 production 환경에서는 로컬스토리지에 저장된 토큰을 가져와 사용
-    setAccessTokens().then(() => setIsServiceReady(true));
-  }, []);
 
   useEffect(() => {
     if (!isServiceReady) return;

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -7,8 +7,9 @@ import { useRouter } from 'next/router';
 
 export default function PostPage() {
   const { query } = useRouter();
+  const { GET } = apiV2.get();
   const data = useQuery({
-    queryFn: () => apiV2.GET('/post/v1/{postId}', { params: { path: { postId: Number(query.id as string) } } }),
+    queryFn: () => GET('/post/v1/{postId}', { params: { path: { postId: Number(query.id as string) } } }),
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     select: res => res.data.data,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,8 @@
 import { paths } from '@/__generated__/schema';
 import axios from 'axios';
 import createClient from 'openapi-fetch';
+import { computed } from 'nanostores';
+import { crewToken, playgroundToken } from '@/stores/tokenStore';
 
 export type PromiseResponse<T> = { data: T; statusCode: number };
 export type Data<T> = PromiseResponse<T>;
@@ -17,8 +19,21 @@ export const api = axios.create({
   baseURL,
 });
 
+crewToken.subscribe(newToken => {
+  api.defaults.headers.common['Authorization'] = `Bearer ${newToken}`;
+});
+
 export const playgroundApi = axios.create({
   baseURL: playgroundBaseURL,
 });
 
-export const apiV2 = createClient<paths>({ baseUrl: baseURL });
+playgroundToken.subscribe(newToken => {
+  playgroundApi.defaults.headers.common['Authorization'] = newToken;
+});
+
+export const apiV2 = computed(crewToken, currentToken =>
+  createClient<paths>({
+    baseUrl: baseURL,
+    headers: currentToken ? { Authorization: `Bearer ${currentToken}` } : {},
+  })
+);

--- a/src/components/util/auth.ts
+++ b/src/components/util/auth.ts
@@ -1,6 +1,6 @@
 import { playgroundLink } from '@sopt-makers/playground-common';
-import { api, playgroundApi } from '@api/index';
 import { getCrewToken } from '@api/auth';
+import { crewToken, playgroundToken } from '@/stores/tokenStore';
 
 // NOTE: playground token 다루는 로직은 추후 다 제거되어야 함
 export const ACCESS_TOKEN_KEY = 'serviceAccessToken';
@@ -29,12 +29,23 @@ export const getCrewServiceToken = async (playgroundToken: string) => {
 };
 
 export const setAccessTokens = async () => {
-  const playgroundToken = getPlaygroundToken();
-  if (!playgroundToken) {
+  // NOTE: development 환경에서는 테스트 토큰을 사용한다.
+  if (process.env.NODE_ENV === 'development') {
+    crewToken.set(
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoi7J207J6s7ZuIIiwiaWQiOjI1NywiaWF0IjoxNjgxODE5NTcxLCJleHAiOjE3MTc4MTk1NzF9.JVG-xzOVikIbX7vj_cZig_TTHxM-EzMgjO-_VGRbLTs'
+    );
+    playgroundToken.set(
+      'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyMyIsImV4cCI6MTY4MjI0NzIzNn0.jPK_OTNXVNvnVFkbdme6tfABsdryUFgXEYOYGCAxdPc'
+    );
+    return;
+  }
+
+  const _playgroundToken = getPlaygroundToken();
+  if (!_playgroundToken) {
     return redirectToLoginPage();
   }
-  const crewToken = await getCrewServiceToken(playgroundToken);
+  const _crewToken = await getCrewServiceToken(_playgroundToken);
 
-  api.defaults.headers.common['Authorization'] = `Bearer ${crewToken}`;
-  playgroundApi.defaults.headers.common['Authorization'] = playgroundToken;
+  crewToken.set(_crewToken);
+  playgroundToken.set(_playgroundToken);
 };

--- a/src/stores/tokenStore.ts
+++ b/src/stores/tokenStore.ts
@@ -1,0 +1,4 @@
+import { atom } from 'nanostores';
+
+export const crewToken = atom<string | undefined>();
+export const playgroundToken = atom<string | undefined>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2892,6 +2892,11 @@
     undici "5.9.1"
     ws "^8.2.2"
 
+"@nanostores/react@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@nanostores/react/-/react-0.7.1.tgz#e0446f5cacc9fa53448c454f5d00ddb0f906a37a"
+  integrity sha512-EXQg9N4MdI4eJQz/AZLIx3hxQ6BuBmV4Q55bCd5YCSgEOAW7tGTsIZxpRXxvxLXzflNvHTBvfrDNY38TlSVBkQ==
+
 "@ndelangen/get-tarball@^3.0.7":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@ndelangen/get-tarball/-/get-tarball-3.0.9.tgz#727ff4454e65f34707e742a59e5e6b1f525d8964"
@@ -9951,6 +9956,11 @@ nanoid@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz"
   integrity sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==
+
+nanostores@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/nanostores/-/nanostores-0.9.3.tgz#a095de5cb695e027b84657d5e31cabd6c5bb269c"
+  integrity sha512-KobZjcVyNndNrb5DAjfs0WG0lRcZu5Q1BOrfTOxokFLi25zFrWPjg+joXC6kuDqNfSt9fQwppyjUBkRPtsL+8w==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
## 🚩 관련 이슈
- close #442 

## 📋 작업 내용
- [x] [nanostore](https://github.com/nanostores/nanostores) 및 [@nanostore/react](https://github.com/nanostores/react) 패키지 설치(가벼운 스토어 역할. 토큰 저장하는데 사용)
- [x] 인증 토큰 적용 로직 수정(axios는 언제든지 수정이 가능한 반면 apiV2는 클라이언트를 생성하는 시점에 헤더를 적용해야 함. 그래서 reactive 하게 동작하도록 로직을 다듬었어요)

