### PR TITLE
피드 상세 페이지 댓글 목록 조회 API 연동

### DIFF
--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -6,13 +6,27 @@ import { useRouter } from 'next/router';
 import { useMutation } from '@tanstack/react-query';
 import { apiV2 } from '@api/index';
 import FeedCommentInput from '@components/feed/FeedCommentInput/FeedCommentInput';
+import FeedCommentViewer from '@components/feed/FeedCommentViewer/FeedCommentViewer';
+import { useQueryMyProfile } from '@api/user/hooks';
 
 export default function PostPage() {
   const { query } = useRouter();
   const { GET, POST } = apiV2.get();
 
+  const { data: me } = useQueryMyProfile();
+
   const data = useQuery({
+    queryKey: ['/post/v1/{postId}', query.id],
     queryFn: () => GET('/post/v1/{postId}', { params: { path: { postId: Number(query.id as string) } } }),
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    select: res => res.data.data,
+    enabled: !!query.id,
+  });
+
+  const commentQuery = useQuery({
+    queryKey: ['/comment/v1', query.id],
+    queryFn: () => GET('/comment/v1', { params: { query: { postId: Number(query.id as string) } } }),
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     select: res => res.data.data,
@@ -31,6 +45,10 @@ export default function PostPage() {
   // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요
   const post = data.data as paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
 
+  // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요
+  const comments = (commentQuery.data as paths['/comment/v1']['get']['responses']['200']['content']['application/json'])
+    ?.comments;
+
   // TODO: loading 스켈레톤 UI가 있으면 좋을 듯
   if (!post) return <Loader />;
 
@@ -39,6 +57,14 @@ export default function PostPage() {
       <FeedPostViewer
         post={post}
         Actions={['수정', '삭제']}
+        CommentList={comments.map(comment => (
+          <FeedCommentViewer
+            key={comment.id}
+            comment={comment}
+            Actions={['수정', '삭제']}
+            isMine={comment.user.id === me?.id}
+          />
+        ))}
         CommentInput={<FeedCommentInput onSubmit={handleCreateComment} disabled={isCreatingComment} />}
       />
     </div>

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -15,7 +15,7 @@ export default function PostPage() {
 
   const { data: me } = useQueryMyProfile();
 
-  const data = useQuery({
+  const postQuery = useQuery({
     queryKey: ['/post/v1/{postId}', query.id],
     queryFn: () => GET('/post/v1/{postId}', { params: { path: { postId: Number(query.id as string) } } }),
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -43,7 +43,7 @@ export default function PostPage() {
   };
 
   // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요
-  const post = data.data as paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
+  const post = postQuery.data as paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
 
   // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요
   const comments = (commentQuery.data as paths['/comment/v1']['get']['responses']['200']['content']['application/json'])

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -40,6 +40,7 @@ export default function PostPage() {
 
   const handleCreateComment = async (comment: string) => {
     await mutateAsync(comment);
+    commentQuery.refetch();
   };
 
   // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요

--- a/src/components/feed/FeedCommentInput/FeedCommentInput.tsx
+++ b/src/components/feed/FeedCommentInput/FeedCommentInput.tsx
@@ -3,7 +3,7 @@ import SendIcon from 'public/assets/svg/send.svg';
 import React, { useState } from 'react';
 
 interface FeedCommentInputProps {
-  onSubmit: (comment: string) => void;
+  onSubmit: (comment: string) => Promise<void>;
   disabled?: boolean;
 }
 
@@ -18,7 +18,7 @@ export default function FeedCommentInput({ onSubmit, disabled }: FeedCommentInpu
     event.preventDefault();
 
     if (!comment.trim()) return;
-    onSubmit(comment);
+    onSubmit(comment).then(() => setComment(''));
   };
 
   return (

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -26,18 +26,20 @@ export default function FeedCommentViewer({ comment, isMine, Actions }: FeedComm
           </Name>
           <Date>{fromNow(comment.updatedDate)}</Date>
         </AuthorWrapper>
-        <Menu as="div" style={{ position: 'relative' }}>
-          <Menu.Button>
-            <MenuIcon />
-          </Menu.Button>
-          <MenuItems>
-            {Actions.map((Action, index) => (
-              <Menu.Item key={index}>
-                <MenuItem>{Action}</MenuItem>
-              </Menu.Item>
-            ))}
-          </MenuItems>
-        </Menu>
+        {isMine && (
+          <Menu as="div" style={{ position: 'relative' }}>
+            <Menu.Button>
+              <MenuIcon />
+            </Menu.Button>
+            <MenuItems>
+              {Actions.map((Action, index) => (
+                <Menu.Item key={index}>
+                  <MenuItem>{Action}</MenuItem>
+                </Menu.Item>
+              ))}
+            </MenuItems>
+          </Menu>
+        )}
       </CommentHeader>
 
       <CommentBody>

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -31,8 +31,8 @@ export default function FeedCommentViewer({ comment, isMine, Actions }: FeedComm
             <MenuIcon />
           </Menu.Button>
           <MenuItems>
-            {Actions.map(Action => (
-              <Menu.Item>
+            {Actions.map((Action, index) => (
+              <Menu.Item key={index}>
                 <MenuItem>{Action}</MenuItem>
               </Menu.Item>
             ))}

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -5,6 +5,7 @@ import { styled } from 'stitches.config';
 import { paths } from '@/__generated__/schema';
 import LikeIcon from 'public/assets/svg/like_in_comment.svg?v2';
 import LikeFillIcon from 'public/assets/svg/like_fill_in_comment.svg?v2';
+import { fromNow } from '@utils/dayjs';
 
 interface FeedCommentViewerProps {
   // TODO: API 응답을 바로 interface에 꽂지 말고 모델 만들어서 사용하자
@@ -23,7 +24,7 @@ export default function FeedCommentViewer({ comment, isMine, Actions }: FeedComm
             {comment.user.name}
             {isMine ? '(글쓴이)' : ''}
           </Name>
-          <Date>{comment.updatedDate}</Date>
+          <Date>{fromNow(comment.updatedDate)}</Date>
         </AuthorWrapper>
         <Menu as="div" style={{ position: 'relative' }}>
           <Menu.Button>

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -9,11 +9,7 @@ import { styled } from 'stitches.config';
 import { Box } from '@components/box/Box';
 import { useOverlay } from '@hooks/useOverlay/Index';
 import ImageCarouselModal from '@components/modal/ImageCarouselModal';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import 'dayjs/locale/ko';
-dayjs.extend(relativeTime);
-dayjs.locale('ko');
+import { fromNow } from '@utils/dayjs';
 
 interface FeedPostViewerProps {
   post: paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
@@ -39,7 +35,7 @@ export default function FeedPostViewer({ post, Actions, CommentList, CommentInpu
             <SAvatar src={post.user.profileImage || ''} alt={post.user.name} />
             <AuthorInfo>
               <AuthorName>{post.user.name}</AuthorName>
-              <UpdatedDate>{dayjs(post.updatedDate).fromNow()}</UpdatedDate>
+              <UpdatedDate>{fromNow(post.updatedDate)}</UpdatedDate>
             </AuthorInfo>
           </AuthorWrapper>
           <Menu as="div" style={{ position: 'relative' }}>

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -43,8 +43,8 @@ export default function FeedPostViewer({ post, Actions, CommentList, CommentInpu
               <MenuIcon />
             </Menu.Button>
             <MenuItems>
-              {Actions.map(Action => (
-                <Menu.Item>
+              {Actions.map((Action, index) => (
+                <Menu.Item key={index}>
                   <MenuItem>{Action}</MenuItem>
                 </Menu.Item>
               ))}

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -18,10 +18,11 @@ dayjs.locale('ko');
 interface FeedPostViewerProps {
   post: paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
   Actions: React.ReactNode[];
+  CommentList: React.ReactNode;
   CommentInput: React.ReactNode;
 }
 
-export default function FeedPostViewer({ post, Actions, CommentInput }: FeedPostViewerProps) {
+export default function FeedPostViewer({ post, Actions, CommentList, CommentInput }: FeedPostViewerProps) {
   const overlay = useOverlay();
 
   const handleClickImage = (images: string[], startIndex: number) => () => {
@@ -89,8 +90,7 @@ export default function FeedPostViewer({ post, Actions, CommentInput }: FeedPost
       </CommentLikeWrapper>
 
       <CommentListWrapper>
-        {/* 댓글 목록 */}
-        <div></div>
+        {CommentList}
         {CommentInput}
       </CommentListWrapper>
     </Container>

--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -1,0 +1,7 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/ko';
+dayjs.extend(relativeTime);
+dayjs.locale('ko');
+
+export const fromNow = (date: string) => dayjs(date).fromNow();


### PR DESCRIPTION
## 🚩 관련 이슈
- close #439 

## 📋 작업 내용
- [x] `FeedPostViewer` 에 댓글 목록 UI를 합성할 수 있게 `CommentList` props interface 추가
- [x] 댓글 목록 조회(`/comment/v1`) API 연동
- [x] `몇 시간 전` 요런 시간 관련 유틸 `fromNow(date)` 함수 추가 및 해당 함수 사용하도록 리팩토링
- [x] `key` props 안줘서 에러나는 것 수정
- [x] 내가 작성한 댓글만 메뉴 버튼 노출해주도록 수정
- [x] 댓글 작성 이후 댓글 목록 refetch 하도록 변경
- [x] 댓글 작성 이후 input 란 초기화

## 📸 스크린샷
<img width="898" alt="Screenshot 2023-09-28 at 12 08 30 AM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/4ec6c9cb-ba4b-4eee-adb8-9b5808073910">

## TODO
- 댓글 개수 & 좋아요 버튼 영역에서 댓글 개수 보여주려면 commentCount 이런 props interface 추가해주어야 하는데, 그것 보단 그냥 이 섹션을 합성할 수 있게 하는게 좋을 것 같아 해당 작업 PR 추가 예정