### PR TITLE
피드 개수 보여주는 부분 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "generate-types": "openapi-typescript ./src/__generated__/open-api-specification.json -o ./src/__generated__/schema.d.ts"
   },
   "dependencies": {
+    "@egjs/react-infinitegrid": "^4.10.1",
     "@headlessui/react": "^1.7.3",
     "@hookform/resolvers": "^2.9.10",
     "@nanostores/react": "^0.7.1",

--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -27,7 +27,7 @@ const DetailPage = () => {
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
 
-  if (!detailData) {
+  if (!detailData || !id) {
     return <Loader />;
   }
 

--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -27,7 +27,7 @@ const DetailPage = () => {
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
 
-  if (!detailData || !id) {
+  if (!detailData) {
     return <Loader />;
   }
 

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -2,7 +2,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { getPosts } from '.';
 
 export const useInfinitePosts = (take: number, meetingId: number) => {
-  const { data, hasNextPage, fetchNextPage } = useInfiniteQuery({
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ['getPosts', take, meetingId],
     queryFn: ({ pageParam = 1 }) => getPosts(pageParam, take, meetingId),
     getNextPageParam: (lastPage, allPages) => {
@@ -26,5 +26,5 @@ export const useInfinitePosts = (take: number, meetingId: number) => {
     }),
   });
 
-  return { data, hasNextPage, fetchNextPage };
+  return { data, hasNextPage, fetchNextPage, isFetchingNextPage };
 };

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -14,7 +14,6 @@ export const useInfinitePosts = (take: number, meetingId: number) => {
       }
       return allPages.length + 1;
     },
-    enabled: !!meetingId,
     select: data => ({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -20,6 +20,9 @@ export const useInfinitePosts = (take: number, meetingId: number) => {
       // @ts-ignore
       pages: data.pages.flatMap(page => page?.data?.posts),
       pageParams: data.pageParams,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      total: data.pages[0]?.data.meta.itemCount,
     }),
   });
 

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -14,6 +14,7 @@ export const useInfinitePosts = (take: number, meetingId: number) => {
       }
       return allPages.length + 1;
     },
+    enabled: !!meetingId,
     select: data => ({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/src/components/page/meetingDetail/Feed/EmptyView.tsx
+++ b/src/components/page/meetingDetail/Feed/EmptyView.tsx
@@ -13,6 +13,7 @@ const EmptyView = ({ isMember }: EmptyViewProps) => {
   return (
     <>
       <SContent>
+        <SEmoji>👀</SEmoji>
         <p>아직 작성된 피드가 없어요.</p>
 
         {isMember && (
@@ -56,5 +57,13 @@ const SContent = styled(Box, {
       borderRadius: '8px',
       fontStyle: 'H4',
     },
+  },
+});
+
+const SEmoji = styled('p', {
+  mb: '$20',
+
+  '@tablet': {
+    mb: '$12',
   },
 });

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -7,17 +7,12 @@ import LikeDefaultIcon from '@assets/svg/like_default.svg';
 import LikeActiveIcon from '@assets/svg/like_active.svg';
 import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
 import Avatar from '@components/avatar/Avatar';
-import dayjs from 'dayjs';
-import relativeTime from 'dayjs/plugin/relativeTime';
-import 'dayjs/locale/ko';
 import { useState } from 'react';
 import truncateText from '@utils/truncateText';
 import { THUMBNAIL_IMAGE_INDEX } from '@constants/index';
 import { AVATAR_MAX_LENGTH, CARD_CONTENT_MAX_LENGTH, CARD_TITLE_MAX_LENGTH, LIKE_MAX_COUNT } from '@constants/feed';
 import { UserResponse } from '@api/user';
-
-dayjs.extend(relativeTime);
-dayjs.locale('ko');
+import { fromNow } from '@utils/dayjs';
 
 interface FeedItemProps {
   user: UserResponse;
@@ -43,7 +38,7 @@ const FeedItem = (post: FeedItemProps) => {
             {user.profileImage ? <SProfileImage src={user.profileImage} alt="" /> : <ProfileDefaultIcon />}
           </SProfileImageWrapper>
           <SName>{user.name}</SName>
-          <STime>{dayjs(updatedDate).fromNow()}</STime>
+          <STime>{fromNow(updatedDate)}</STime>
         </Flex>
         {/* <MoreIcon /> */}
       </STop>

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -30,6 +30,11 @@ const FeedItem = (post: FeedItemProps) => {
   const formattedLikeCount = likeCount > LIKE_MAX_COUNT ? `${LIKE_MAX_COUNT}+` : likeCount;
   const [like, setLike] = useState(false);
 
+  const handleLikeClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setLike(prev => !prev);
+  };
+
   return (
     <SFeedItem>
       <STop>
@@ -75,7 +80,7 @@ const FeedItem = (post: FeedItemProps) => {
           </SCommentWrapper>
         </Flex>
 
-        <SLikeButton like={like} onClick={() => setLike(prev => !prev)}>
+        <SLikeButton like={like} onClick={e => handleLikeClick(e)}>
           {like ? <LikeActiveIcon /> : <LikeDefaultIcon />}
           {formattedLikeCount}
         </SLikeButton>

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -200,7 +200,6 @@ const SCommentWrapper = styled('div', {
   variants: {
     hasComment: {
       true: {
-        transform: 'translateX(-66%)',
         ml: '$8',
       },
     },

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -93,11 +93,15 @@ export default FeedItem;
 
 const SFeedItem = styled(Box, {
   padding: '$24 $20 $28 $20',
+  background: '#171818',
+  borderRadius: '12px',
   color: '$white100',
   width: '100%',
 
   '@tablet': {
     padding: '$24 0 $28 0',
+    background: 'transparent',
+    borderRadius: 0,
     margin: '0 auto',
   },
 });

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -12,6 +12,7 @@ import FeedCreateModal from './Modal/FeedCreateModal';
 import { useDisplay } from '@hooks/useDisplay';
 import MobileFeedListSkeleton from './Skeleton/MobileFeedListSkeleton';
 import DesktopFeedListSkeleton from './Skeleton/DesktopFeedListSkeleton';
+import Link from 'next/link';
 
 interface FeedPanelProps {
   isMember: boolean;
@@ -61,7 +62,14 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
 
       <SFeedContainer>
         {postsData?.pages.map(post => {
-          if (post) return <FeedItem key={post.id} {...post} />;
+          if (post)
+            return (
+              <Link href={`/post?id=${post.id}`}>
+                <a>
+                  <FeedItem key={post.id} {...post} />
+                </a>
+              </Link>
+            );
         })}
       </SFeedContainer>
       <div ref={setTarget} />

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -64,9 +64,9 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
         {postsData?.pages.map(post => {
           if (post)
             return (
-              <Link href={`/post?id=${post.id}`}>
+              <Link href={`/post?id=${post.id}`} key={post.id}>
                 <a>
-                  <FeedItem key={post.id} {...post} />
+                  <FeedItem {...post} />
                 </a>
               </Link>
             );

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -13,6 +13,7 @@ import { useDisplay } from '@hooks/useDisplay';
 import MobileFeedListSkeleton from './Skeleton/MobileFeedListSkeleton';
 import DesktopFeedListSkeleton from './Skeleton/DesktopFeedListSkeleton';
 import Link from 'next/link';
+import { MasonryInfiniteGrid } from '@egjs/react-infinitegrid';
 
 interface FeedPanelProps {
   isMember: boolean;
@@ -41,6 +42,14 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
   };
   const { setTarget } = useIntersectionObserver({ onIntersect });
 
+  const renderedPosts = postsData?.pages.map(post => (
+    <Link href={`/post?id=${post.id}`} key={post.id}>
+      <a>
+        <FeedItem {...post} />
+      </a>
+    </Link>
+  ));
+
   return (
     <>
       {isEmpty && (
@@ -60,18 +69,13 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
         </SHeader>
       )}
 
-      <SFeedContainer>
-        {postsData?.pages.map(post => {
-          if (post)
-            return (
-              <Link href={`/post?id=${post.id}`} key={post.id}>
-                <a>
-                  <FeedItem {...post} />
-                </a>
-              </Link>
-            );
-        })}
-      </SFeedContainer>
+      {isTablet ? (
+        <SMobileContainer>{renderedPosts}</SMobileContainer>
+      ) : (
+        <SDesktopContainer align="left" gap={30}>
+          {renderedPosts}
+        </SDesktopContainer>
+      )}
       <div ref={setTarget} />
 
       {isFetchingNextPage &&
@@ -97,18 +101,17 @@ const SContainer = styled(Box, {
   },
 });
 
-const SFeedContainer = styled(Box, {
-  display: 'grid',
-  gap: '30px',
-  gridTemplateColumns: '1fr 1fr 1fr',
+const SDesktopContainer = styled(MasonryInfiniteGrid, {
   marginTop: '$32',
-  width: '100%',
-
-  '@tablet': {
-    display: 'flex',
-    flexDirection: 'column',
-    marginTop: 0,
+  a: {
+    minWidth: 'calc(calc(100% - 60px) / 3)',
   },
+});
+
+const SMobileContainer = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  marginTop: 0,
 });
 
 const SHeader = styled('div', {

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -10,6 +10,8 @@ import { POST_MAX_COUNT, TAKE_COUNT } from '@constants/feed';
 import useModal from '@hooks/useModal';
 import FeedCreateModal from './Modal/FeedCreateModal';
 import { useDisplay } from '@hooks/useDisplay';
+import MobileFeedListSkeleton from './Skeleton/MobileFeedListSkeleton';
+import DesktopFeedListSkeleton from './Skeleton/DesktopFeedListSkeleton';
 
 interface FeedPanelProps {
   isMember: boolean;
@@ -20,7 +22,12 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
   const meetingId = router.query.id as string;
   const feedCreateModal = useModal();
   const { isTablet } = useDisplay();
-  const { data: postsData, fetchNextPage, hasNextPage } = useInfinitePosts(TAKE_COUNT, Number(meetingId));
+  const {
+    data: postsData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfinitePosts(TAKE_COUNT, Number(meetingId));
   const isEmpty = !postsData?.pages[0];
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
@@ -58,6 +65,9 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
         })}
       </SFeedContainer>
       <div ref={setTarget} />
+
+      {isFetchingNextPage &&
+        (isTablet ? <MobileFeedListSkeleton count={3} /> : <DesktopFeedListSkeleton row={2} column={3} />)}
 
       <FeedCreateModal
         isModalOpened={feedCreateModal.isModalOpened}

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -11,7 +11,6 @@ import useModal from '@hooks/useModal';
 import FeedCreateModal from './Modal/FeedCreateModal';
 import { useDisplay } from '@hooks/useDisplay';
 import MobileFeedListSkeleton from './Skeleton/MobileFeedListSkeleton';
-import DesktopFeedListSkeleton from './Skeleton/DesktopFeedListSkeleton';
 import Link from 'next/link';
 import { MasonryInfiniteGrid } from '@egjs/react-infinitegrid';
 
@@ -78,8 +77,7 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
       )}
       <div ref={setTarget} />
 
-      {isFetchingNextPage &&
-        (isTablet ? <MobileFeedListSkeleton count={3} /> : <DesktopFeedListSkeleton row={2} column={3} />)}
+      {isFetchingNextPage && isTablet && <MobileFeedListSkeleton count={3} />}
 
       <FeedCreateModal
         isModalOpened={feedCreateModal.isModalOpened}

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 import { useInfinitePosts } from '@api/post/hooks';
 import FeedItem from './FeedItem';
 import { useIntersectionObserver } from '@hooks/useIntersectionObserver';
-import { TAKE_COUNT } from '@constants/feed';
+import { POST_MAX_COUNT, TAKE_COUNT } from '@constants/feed';
 import useModal from '@hooks/useModal';
 import FeedCreateModal from './Modal/FeedCreateModal';
 import { useDisplay } from '@hooks/useDisplay';
@@ -24,7 +24,8 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
   const isEmpty = !postsData?.pages[0];
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const count = postsData?.total;
+  const postCount = postsData?.total;
+  const formattedPostCount = postCount > POST_MAX_COUNT ? `${POST_MAX_COUNT}+` : postCount;
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isIntersecting && hasNextPage) {
       fetchNextPage();
@@ -40,10 +41,10 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
         </SContainer>
       )}
 
-      {count && (
+      {postCount && (
         <SHeader>
           <p>
-            🔥 지금까지 쌓인 피드 <SCount>{count}</SCount>개
+            🔥 지금까지 쌓인 피드 <SCount>{formattedPostCount}</SCount>개
           </p>
           {isMember && (
             <SButton onClick={feedCreateModal.handleModalOpen}>{isTablet ? '+ 작성' : '나도 작성하기'}</SButton>

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -104,7 +104,7 @@ const SContainer = styled(Box, {
 const SDesktopContainer = styled(MasonryInfiniteGrid, {
   marginTop: '$32',
   a: {
-    minWidth: 'calc(calc(100% - 60px) / 3)',
+    width: 'calc(calc(100% - 60px) / 3)',
   },
 });
 
@@ -118,6 +118,7 @@ const SHeader = styled('div', {
   flexType: 'center',
   padding: '$31 0',
   fontStyle: 'H1',
+  color: '$gray40',
 
   '@tablet': {
     padding: '$16 $20',
@@ -131,7 +132,7 @@ const SHeader = styled('div', {
 });
 
 const SCount = styled('span', {
-  color: '$orange100',
+  color: '$white100',
 });
 
 const SButton = styled('button', {

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -7,6 +7,9 @@ import { useInfinitePosts } from '@api/post/hooks';
 import FeedItem from './FeedItem';
 import { useIntersectionObserver } from '@hooks/useIntersectionObserver';
 import { TAKE_COUNT } from '@constants/feed';
+import useModal from '@hooks/useModal';
+import FeedCreateModal from './Modal/FeedCreateModal';
+import { useDisplay } from '@hooks/useDisplay';
 
 interface FeedPanelProps {
   isMember: boolean;
@@ -15,8 +18,13 @@ interface FeedPanelProps {
 const FeedPanel = ({ isMember }: FeedPanelProps) => {
   const router = useRouter();
   const meetingId = router.query.id as string;
+  const feedCreateModal = useModal();
+  const { isTablet } = useDisplay();
   const { data: postsData, fetchNextPage, hasNextPage } = useInfinitePosts(TAKE_COUNT, Number(meetingId));
   const isEmpty = !postsData?.pages[0];
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const count = postsData?.total;
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isIntersecting && hasNextPage) {
       fetchNextPage();
@@ -32,12 +40,28 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
         </SContainer>
       )}
 
+      {count && (
+        <SHeader>
+          <p>
+            🔥 지금까지 쌓인 피드 <SCount>{count}</SCount>개
+          </p>
+          {isMember && (
+            <SButton onClick={feedCreateModal.handleModalOpen}>{isTablet ? '+ 작성' : '나도 작성하기'}</SButton>
+          )}
+        </SHeader>
+      )}
+
       <SFeedContainer>
         {postsData?.pages.map(post => {
           if (post) return <FeedItem key={post.id} {...post} />;
         })}
       </SFeedContainer>
       <div ref={setTarget} />
+
+      <FeedCreateModal
+        isModalOpened={feedCreateModal.isModalOpened}
+        handleModalClose={feedCreateModal.handleModalClose}
+      />
     </>
   );
 };
@@ -58,12 +82,49 @@ const SFeedContainer = styled(Box, {
   display: 'grid',
   gap: '30px',
   gridTemplateColumns: '1fr 1fr 1fr',
-  marginTop: '$56',
+  marginTop: '$32',
   width: '100%',
 
   '@tablet': {
     display: 'flex',
     flexDirection: 'column',
     marginTop: 0,
+  },
+});
+
+const SHeader = styled('div', {
+  flexType: 'center',
+  padding: '$31 0',
+  fontStyle: 'H1',
+
+  '@tablet': {
+    padding: '$16 $20',
+    fontStyle: 'H5',
+    backgroundColor: '$black80',
+    mt: '$28',
+    borderRadius: '12px',
+    flexType: 'verticalCenter',
+    justifyContent: 'space-between',
+  },
+});
+
+const SCount = styled('span', {
+  color: '$orange100',
+});
+
+const SButton = styled('button', {
+  backgroundColor: '$black40',
+  fontStyle: 'H2',
+  ml: '$48',
+  color: '$white',
+  padding: '$16 $36',
+  borderRadius: '14px',
+
+  '@tablet': {
+    backgroundColor: '$orange100',
+    fontStyle: 'T5',
+    ml: '$20',
+    padding: '$6 $12',
+    borderRadius: '8px',
   },
 });

--- a/src/constants/feed.ts
+++ b/src/constants/feed.ts
@@ -1,4 +1,5 @@
 export const LIKE_MAX_COUNT = 999;
+export const POST_MAX_COUNT = 999;
 export const AVATAR_MAX_LENGTH = 3;
 export const CARD_TITLE_MAX_LENGTH = 40;
 export const CARD_CONTENT_MAX_LENGTH = 70;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,6 +2175,20 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cfcs/core@^0.0.24":
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/@cfcs/core/-/core-0.0.24.tgz#2ab40d1fe5cf64f50acc31983a5b589521268dde"
+  integrity sha512-feB38qu+eDk0Pggh/yR7gjaNmvUYA2uCxHP3Pz2MLE4LZ/9jPdtu8bzCSI47yTEhWyZCF5Pk698hdz8IN2mTjA==
+  dependencies:
+    "@egjs/component" "^3.0.4"
+
+"@cfcs/core@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@cfcs/core/-/core-0.0.5.tgz#b3d3ce36630016e0c0bb10848e1205fc216493e3"
+  integrity sha512-TZ/RXKV7MUrqFpiX+16uaaptv5jgChWNsuE6w8Rn3eJbO1PFd4Wpn25zeJbii7ch46ck8/ZIIYCcW3pHiYtm4Q==
+  dependencies:
+    "@egjs/component" "^3.0.2"
+
 "@cloudflare/kv-asset-handler@^0.2.0":
   version "0.2.0"
   resolved "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.2.0.tgz"
@@ -2208,6 +2222,58 @@
   integrity sha512-BOLrAX8IWHRXu1siZocwLguKJPEUv7cr+rG8tI4hvHgMdIsBWHJlLeB8EjuUVnIURFrUiM49lVKn8DRrECmngw==
   dependencies:
     "@edge-runtime/primitives" "2.0.0"
+
+"@egjs/children-differ@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@egjs/children-differ/-/children-differ-1.0.1.tgz#5465fa80671d5ca3564ebe912f48b05b3e8a14fd"
+  integrity sha512-DRvyqMf+CPCOzAopQKHtW+X8iN6Hy6SFol+/7zCUiE5y4P/OB8JP8FtU4NxtZwtafvSL4faD5KoQYPj3JHzPFQ==
+  dependencies:
+    "@egjs/list-differ" "^1.0.0"
+
+"@egjs/component@^3.0.0", "@egjs/component@^3.0.1", "@egjs/component@^3.0.2", "@egjs/component@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@egjs/component/-/component-3.0.4.tgz#ad7b53794b2a612806179a188ad828acb9525f61"
+  integrity sha512-sXA7bGbIeLF2OAw/vpka66c6QBBUPcA4UUhR4WGJfnp2XWdiI8QrnJGJMr/UxpE/xnevX9tN3jvNPlW8WkHl3g==
+
+"@egjs/grid@^1.14.2":
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/@egjs/grid/-/grid-1.14.2.tgz#b92c91298a808c7549219904ed2396361c4cc1b8"
+  integrity sha512-MOIL6zdFmEFYVmlsrPr8eNPybDZqRKzJo1sceFiamAvxWJ+5yG17tVRP9zMSeXogjsShWhNUKqoPOUC4rClFAQ==
+  dependencies:
+    "@egjs/children-differ" "^1.0.1"
+    "@egjs/component" "^3.0.0"
+    "@egjs/imready" "^1.3.0"
+
+"@egjs/imready@^1.3.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@egjs/imready/-/imready-1.4.1.tgz#4d72f67b5e8212f0ef449dd2b5b79f975110352b"
+  integrity sha512-JIOBs4lB7FYdsKi5uvz2j3SObX8eShtZjtqlOH41tm185aJOQZwiKBK8+V4MxzG4X6DqVhpdN8UcuVwBbElfsg==
+  dependencies:
+    "@cfcs/core" "^0.0.24"
+    "@egjs/component" "^3.0.1"
+
+"@egjs/infinitegrid@~4.10.1":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@egjs/infinitegrid/-/infinitegrid-4.10.1.tgz#02dda423f29775b972eda449755ef25cb6aa2854"
+  integrity sha512-hucrUJgSGeze6jH9HdWtLmDKR0ssx42JyXFDGQ2MrOZDmf6WQlky0fXer8FJzBaKQdraODH9bz0TKjIWzG7gaA==
+  dependencies:
+    "@cfcs/core" "^0.0.5"
+    "@egjs/children-differ" "^1.0.1"
+    "@egjs/component" "^3.0.0"
+    "@egjs/grid" "^1.14.2"
+    "@egjs/list-differ" "^1.0.0"
+
+"@egjs/list-differ@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@egjs/list-differ/-/list-differ-1.0.1.tgz#5772b0f8b87973bb67827f6c7d7df8d7f64a22eb"
+  integrity sha512-OTFTDQcWS+1ZREOdCWuk5hCBgYO4OsD30lXcOCyVOAjXMhgL5rBRDnt/otb6Nz8CzU0L/igdcaQBDLWc4t9gvg==
+
+"@egjs/react-infinitegrid@^4.10.1":
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/@egjs/react-infinitegrid/-/react-infinitegrid-4.10.1.tgz#673d55ce9dc1e18772b48c1e6956bbface8fc73d"
+  integrity sha512-4mACfw49TMkZ1RtxhMi30u3e314c4CQnwrBtWVrOTQbKa3g/Xdy3eHJ1xjaN6D9OPrtIZ+VH2Aby/RvRj8LoYA==
+  dependencies:
+    "@egjs/infinitegrid" "~4.10.1"
 
 "@emotion/babel-plugin@^11.10.6", "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"


### PR DESCRIPTION
## 🚩 관련 이슈
- close #448 

## 📋 작업 내용
- [x] 데스크탑
- [x] 모바일
- [x] 모임 참여자의 경우, 개수 우측에 작성 버튼 추가
- [x] 999개 초과인 경우 처리

## 📌 PR Point
- 피드 개수는 `useInfinitePosts`에서 `total`로 가져왔어요.
- `useInfinitePosts` 수정하면서 `isFetchingNextPage`도 추가하고 전에 미리 만들어둔 스켈레톤도 적용했어요.
- 피드 아이템을 누르면 상세 페이지로 이동하도록 설정했어요.

## 📸 스크린샷
|데스크탑|모바일|
|:-:|:-:|
|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/6fe9599a-5044-40d3-8b3b-a181ff559d70)|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/15178e93-5f56-48ac-bd73-ef621423cfe0)|

(개수 부분에 있는 텍스트 색깔 변경되어서 지금이랑 달라요! 스크린샷은 구조만 봐주세용)