### PR TITLE
피드 상세 뷰 댓글 목록 무한스크롤 적용

### DIFF
--- a/src/hooks/useComment.ts
+++ b/src/hooks/useComment.ts
@@ -1,0 +1,35 @@
+import { apiV2 } from '@api/index';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+
+export default function useComment() {
+  const { query } = useRouter();
+  const { GET } = apiV2.get();
+
+  const commentQuery = useInfiniteQuery({
+    queryKey: ['/comment/v1', query.id],
+    queryFn: ({ pageParam = 1 }) =>
+      GET('/comment/v1', { params: { query: { postId: Number(query.id as string), page: pageParam } } }),
+    getNextPageParam: lastPage => {
+      // TODO: 서버 스키마 변경 후 수정 필요
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      if (!lastPage.data?.data?.meta.hasNextPage) return;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return (lastPage?.data?.data?.meta.page as number) + 1;
+    },
+    getPreviousPageParam: firstPage => {
+      // TODO: 서버 스키마 변경 후 수정 필요
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      if (!firstPage.data?.data?.meta.hasPreviousPage) return;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      return (firstPage?.data?.data?.meta.page as number) - 1;
+    },
+    enabled: !!query.id,
+  });
+
+  return commentQuery;
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #453 

## 📋 작업 내용
- [x] `/comment/v1` API 호출하는 훅 `useComment` 추가
- [x] 피드 상세 뷰 페이지에서 `useComment` 와 `useIntersectionObserver` 훅 사용해서 댓글 무한스크롤 구현

## 📸 스크린샷

https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/83c25f04-07e9-4101-876a-5faa224eb7a4


