### PR TITLE
댓글 삭제 API 연동

### DIFF
--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -1,9 +1,8 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { getPosts } from '.';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { postLike } from '.';
 import { produce } from 'immer';
 import { paths } from '@/__generated__/schema';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteComment, getPosts } from '.';
 
 export const useInfinitePosts = (take: number, meetingId: number) => {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage } = useInfiniteQuery({
@@ -58,6 +57,17 @@ export const useMutationPostLike = (queryId: string) => {
       });
 
       queryClient.setQueryData(['/post/v1/{postId}', queryId], data);
+    },
+  });
+};
+
+export const useDeleteComment = (commentId: number, queryId: string) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: ['deleteComment', commentId],
+    mutationFn: () => deleteComment(commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['/comment/v1', queryId] });
     },
   });
 };

--- a/src/api/post/index.ts
+++ b/src/api/post/index.ts
@@ -14,3 +14,6 @@ export const postLike = async (queryId: string) => {
   const { POST } = apiV2.get();
   return await POST('/post/v1/{postId}/like', { params: { path: { postId: Number(queryId) } } });
 };
+export const deleteComment = async (commentId: number) => {
+  return (await api.delete(`/comment/v1/${commentId}`)).data;
+};

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -7,6 +7,7 @@ import LikeIcon from 'public/assets/svg/like_in_comment.svg?v2';
 import LikeFillIcon from 'public/assets/svg/like_fill_in_comment.svg?v2';
 import { fromNow } from '@utils/dayjs';
 import ConfirmModal from '@components/modal/ConfirmModal';
+import { useState } from 'react';
 
 interface FeedCommentViewerProps {
   // TODO: API 응답을 바로 interface에 꽂지 말고 모델 만들어서 사용하자
@@ -17,11 +18,17 @@ interface FeedCommentViewerProps {
 }
 
 export default function FeedCommentViewer({ comment, isMine, Actions, onClickLike }: FeedCommentViewerProps) {
+  const [isModalOpened, setIsModalOpened] = useState(false);
   const handleModalClose = () => {
-    console.log('close');
+    setIsModalOpened(false);
   };
   const handleConfirm = () => {
     console.log('confirm');
+  };
+  const handleMenuItemClick = (Action: React.ReactNode) => {
+    if (Action === '삭제') {
+      setIsModalOpened(true);
+    }
   };
 
   return (
@@ -43,7 +50,7 @@ export default function FeedCommentViewer({ comment, isMine, Actions, onClickLik
             <MenuItems>
               {Actions.map((Action, index) => (
                 <Menu.Item key={index}>
-                  <MenuItem>{Action}</MenuItem>
+                  <MenuItem onClick={() => handleMenuItemClick(Action)}>{Action}</MenuItem>
                 </Menu.Item>
               ))}
             </MenuItems>
@@ -61,7 +68,7 @@ export default function FeedCommentViewer({ comment, isMine, Actions, onClickLik
         </CommentLikeWrapper>
       </CommentBody>
       <ConfirmModal
-        isModalOpened={true}
+        isModalOpened={isModalOpened}
         message="댓글을 삭제하시겠습니까?"
         cancelButton="돌아가기"
         confirmButton="삭제하기"

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -8,6 +8,8 @@ import LikeFillIcon from 'public/assets/svg/like_fill_in_comment.svg?v2';
 import { fromNow } from '@utils/dayjs';
 import ConfirmModal from '@components/modal/ConfirmModal';
 import { useState } from 'react';
+import { useDeleteComment } from '@api/post/hooks';
+import { useRouter } from 'next/router';
 
 interface FeedCommentViewerProps {
   // TODO: API 응답을 바로 interface에 꽂지 말고 모델 만들어서 사용하자
@@ -19,11 +21,14 @@ interface FeedCommentViewerProps {
 
 export default function FeedCommentViewer({ comment, isMine, Actions, onClickLike }: FeedCommentViewerProps) {
   const [isModalOpened, setIsModalOpened] = useState(false);
+  const { query } = useRouter();
+  const { mutate } = useDeleteComment(comment.id, query.id as string);
   const handleModalClose = () => {
     setIsModalOpened(false);
   };
   const handleConfirm = () => {
-    console.log('confirm');
+    mutate();
+    setIsModalOpened(false);
   };
   const handleMenuItemClick = (Action: React.ReactNode) => {
     if (Action === '삭제') {

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -20,19 +20,19 @@ interface FeedCommentViewerProps {
 }
 
 export default function FeedCommentViewer({ comment, isMine, Actions, onClickLike }: FeedCommentViewerProps) {
-  const [isModalOpened, setIsModalOpened] = useState(false);
+  const [isDeleteModalOpened, setIsDeleteModalOpened] = useState(false);
   const { query } = useRouter();
   const { mutate } = useDeleteComment(comment.id, query.id as string);
-  const handleModalClose = () => {
-    setIsModalOpened(false);
+  const handleDeleteModalClose = () => {
+    setIsDeleteModalOpened(false);
   };
-  const handleConfirm = () => {
+  const handleDeleteConfirm = () => {
     mutate();
-    setIsModalOpened(false);
+    setIsDeleteModalOpened(false);
   };
   const handleMenuItemClick = (Action: React.ReactNode) => {
     if (Action === '삭제') {
-      setIsModalOpened(true);
+      setIsDeleteModalOpened(true);
     }
   };
 
@@ -73,12 +73,12 @@ export default function FeedCommentViewer({ comment, isMine, Actions, onClickLik
         </CommentLikeWrapper>
       </CommentBody>
       <ConfirmModal
-        isModalOpened={isModalOpened}
+        isModalOpened={isDeleteModalOpened}
         message="댓글을 삭제하시겠습니까?"
         cancelButton="돌아가기"
         confirmButton="삭제하기"
-        handleModalClose={handleModalClose}
-        handleConfirm={handleConfirm}
+        handleModalClose={handleDeleteModalClose}
+        handleConfirm={handleDeleteConfirm}
       ></ConfirmModal>
     </Container>
   );


### PR DESCRIPTION
## 🚩 관련 이슈
- close #460 

## 📋 작업 내용
- [x] 삭제 api hook 제작 
- [x] invalidateQuerys 사용해 데이터 최신화

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
1. apiV2 를 사용하고 싶었는데,, apiV2 DELETE 에는 어떤 형식만 들어갈 수 있어서, 댓글 삭제 url 을 넣으니까 입력할 수 없다고 해가지고,, 우선 api 를 이용했습니당 ㅠ^ㅠ
2. CommentList 에서 옵셔널 체이닝 붙여준 건, 댓글이 0개일 때 서버에서 빈 배열을 넘겨주는 게 아니라 undefined 가 될 수도 있어서..! 요건 서버 스앵님들께서 고쳐주시면 바로 고치겠습니당!-!
+++++++
늦은 시간까지 나의 쓸데없는 질문을 받아준,,, 은수 오빠와 지연 언니 고마와,,, + 아빠도 늘 고마와🌷🚀 🌕 
## 📸 스크린샷

https://github.com/sopt-makers/sopt-crew-frontend/assets/86764406/e6970630-9822-4d82-9ab8-301bfcbda020


