### PR TITLE
피드 목록 조회 API 인증 안되는 이슈 수정

### DIFF
--- a/src/api/post/index.ts
+++ b/src/api/post/index.ts
@@ -1,12 +1,12 @@
 import { FormType } from '@components/page/meetingDetail/Feed/Modal/schema';
 import { Data, api, apiV2 } from '..';
-const { GET } = apiV2.get();
 
 export const createPost = async (formData: FormType) => {
   const { data } = await api.post<Data<{ postId: number }>>('/post/v1', formData);
   return data;
 };
 export const getPosts = async (page: number, take: number, meetingId: number) => {
+  const { GET } = apiV2.get();
   const { data } = await GET('/post/v1', { params: { query: { page, take, meetingId } } });
   return data;
 };


### PR DESCRIPTION
## 📋 작업 내용
- [x] 피드 목록 조회 API 에서 401 이슈가 나는 걸 해결했어요. `apiV2.get()` 을 해서 함수를 가져올 때 reactivity 가 제대로 동작하지 않는 이슈가 있어요. `getPosts()` 함수 안에서 호출하면 해결되서 일단 이렇게 수정했어요. 
