### PR TITLE
댓글 수정 기능 추가

### DIFF
--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -30,7 +30,7 @@ export default function PostPage() {
 
   const { mutateAsync, isLoading: isCreatingComment } = useMutation({
     mutationKey: ['/comment/v1'],
-    mutationFn: (comment: string) => POST('/comment/v1', { body: { postId: post.id, contents: comment } }),
+    mutationFn: (comment: string) => POST('/comment/v1', { body: { postId: post!.id, contents: comment } }),
   });
 
   const { mutate: toggleCommentLike } = useCommentMutation();
@@ -49,22 +49,9 @@ export default function PostPage() {
 
   const { mutate: togglePostLike } = useMutationPostLike(query.id as string);
 
-  // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요
-  const post = postQuery.data as paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
+  const post = postQuery.data;
 
-  const comments = commentQuery.data?.pages
-    // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    .flatMap(page => page.data?.data?.comments)
-    // NOTE: flatMap시 배열 아이템으로 undefined 타입이 함께 잡혀서 custom type guard 적용해서 필터링해주자
-    // eslint-disable-next-line prettier/prettier
-    .filter(
-      (
-        comment
-      ): comment is paths['/comment/v1']['get']['responses']['200']['content']['application/json']['comments'][number] =>
-        !!comment
-    );
+  const comments = commentQuery.data?.pages.flatMap(page => page.data?.data?.comments).filter(comment => !!comment);
 
   // TODO: loading 스켈레톤 UI가 있으면 좋을 듯
   if (!post) return <Loader />;
@@ -77,10 +64,7 @@ export default function PostPage() {
         CommentLikeSection={
           <FeedCommentLikeSection
             isLiked={post.isLiked}
-            // TODO: 자동으로 타입 추론 되게끔 endpoint 수정 필요
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            commentCount={commentQuery.data?.pages[0].data?.data?.meta.itemCount}
+            commentCount={commentQuery.data?.pages[0].data?.data?.meta.itemCount || 0}
             likeCount={post.likeCount}
             onClickLike={togglePostLike}
           />

--- a/src/__generated__/schema.d.ts
+++ b/src/__generated__/schema.d.ts
@@ -1130,6 +1130,8 @@ export interface components {
     PostV1GetPostsResponsePostUserDto: {
       /** @description 작성자 고유 ID */
       id: number;
+      /** @description 작성자 playground 고유 ID */
+      orgId: number;
       /** @description 작성자 명 */
       name: string;
       /** @description 작성자 프로필 */
@@ -1169,10 +1171,26 @@ export interface components {
     PostV1GetPostResponseUserDto: {
       /** @description 작성자 고유 ID */
       id: number;
+      /** @description 작성자 playground 고유 ID */
+      orgId: number;
       /** @description 작성자 명 */
       name: string;
       /** @description 작성자 프로필 */
       profileImage: string | null;
+    };
+    PostV1GetPostResponseImageUrlDto: {
+      id: number;
+      url: string;
+    };
+    PostV1GetPostResponseMeetingDto: {
+      /** @description 모임 고유 ID */
+      id: number;
+      /** @description 모임 제목 */
+      title: string;
+      /** @description 모임 이미지 */
+      imageURL: components["schemas"]["PostV1GetPostResponseImageUrlDto"][];
+      /** @description 모임 카테고리 */
+      category: string;
     };
     PostV1GetPostResponseDto: {
       /** @description 게시글 고유 ID */
@@ -1190,6 +1208,8 @@ export interface components {
       images: string[] | null;
       /** @description 작성자 정보 */
       user: components["schemas"]["PostV1GetPostResponseUserDto"];
+      /** @description 미팅 정보 */
+      meeting: components["schemas"]["PostV1GetPostResponseMeetingDto"];
       /** @description 조회수 */
       viewCount: number;
       /** @description 좋아요 수 */
@@ -1258,6 +1278,8 @@ export interface components {
     CommentV1GetCommentsResponseCommentUserDto: {
       /** @description 작성자 고유 ID */
       id: number;
+      /** @description 작성자 playground 고유 ID */
+      orgId: number;
       /** @description 작성자 명 */
       name: string;
       /** @description 작성자 프로필 */
@@ -1728,7 +1750,7 @@ export interface operations {
       };
     };
     responses: {
-      204: never;
+      200: never;
       /** @description "이미지 파일이 없습니다." or "한 개 이상의 파트를 입력해주세요" or "조건에 맞는 모임이 없습니다." */
       400: {
         content: {

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -10,8 +10,6 @@ export const useInfinitePosts = (take: number, meetingId: number) => {
     queryKey: ['getPosts', take, meetingId],
     queryFn: ({ pageParam = 1 }) => getPosts(pageParam, take, meetingId),
     getNextPageParam: (lastPage, allPages) => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       const posts = lastPage?.data?.posts;
       if (!posts || posts.length === 0) {
         return undefined;
@@ -20,12 +18,8 @@ export const useInfinitePosts = (take: number, meetingId: number) => {
     },
     enabled: !!meetingId,
     select: data => ({
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       pages: data.pages.flatMap(page => page?.data?.posts),
       pageParams: data.pageParams,
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       total: data.pages[0]?.data.meta.itemCount,
     }),
   });
@@ -37,15 +31,13 @@ export const useQueryGetPost = (postId: string) => {
   return useQuery({
     queryKey: ['getPost', postId],
     queryFn: () => getPost(postId),
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    select: res => res.data,
+    select: res => res?.data,
     enabled: !!postId,
   });
 };
 
 type postType = {
-  data: paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
+  data: paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json']['data'];
 };
 
 export const useMutationPostLike = (queryId: string) => {

--- a/src/components/feed/FeedActionButton/FeedActionButton.tsx
+++ b/src/components/feed/FeedActionButton/FeedActionButton.tsx
@@ -1,11 +1,19 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, forwardRef } from 'react';
 import { styled } from 'stitches.config';
 
 type FeedActionButtonProps = React.HTMLAttributes<HTMLButtonElement>;
 
-export default function FeedActionButton({ children, ...rest }: PropsWithChildren<FeedActionButtonProps>) {
-  return <MenuItem {...rest}>{children}</MenuItem>;
-}
+const FeedActionButton = forwardRef<HTMLButtonElement, PropsWithChildren<FeedActionButtonProps>>(
+  ({ children, ...rest }, ref) => {
+    return (
+      <MenuItem ref={ref} {...rest}>
+        {children}
+      </MenuItem>
+    );
+  }
+);
+
+export default FeedActionButton;
 
 const MenuItem = styled('button', {
   flexType: 'center',

--- a/src/components/feed/FeedCommentContainer/FeedCommentContainer.tsx
+++ b/src/components/feed/FeedCommentContainer/FeedCommentContainer.tsx
@@ -1,0 +1,77 @@
+import { paths } from '@/__generated__/schema';
+import FeedCommentViewer from '../FeedCommentViewer/FeedCommentViewer';
+import FeedActionButton from '../FeedActionButton/FeedActionButton';
+import { useOverlay } from '@hooks/useOverlay/Index';
+import ConfirmModal from '@components/modal/ConfirmModal';
+import { useState } from 'react';
+import { useDeleteComment } from '@api/post/hooks';
+import { useRouter } from 'next/router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiV2 } from '@api/index';
+import FeedCommentEditor from '../FeedCommentEditor/FeedCommentEditor';
+
+interface FeedCommentContainerProps {
+  comment: paths['/comment/v1']['get']['responses']['200']['content']['application/json']['data']['comments'][number];
+  isMine: boolean;
+  onClickLike: () => void;
+}
+
+export default function FeedCommentContainer({ comment, isMine, onClickLike }: FeedCommentContainerProps) {
+  const queryClient = useQueryClient();
+  const { PUT } = apiV2.get();
+  const { query } = useRouter();
+  const overlay = useOverlay();
+  const [editMode, setEditMode] = useState(false);
+
+  const { mutate: mutateDeleteComment } = useDeleteComment(query.id as string);
+
+  const { mutateAsync: mutateEditComment } = useMutation({
+    mutationFn: (contents: string) =>
+      PUT('/comment/v1/{commentId}', { params: { path: { commentId: comment.id } }, body: { contents } }),
+    onSuccess: () => queryClient.invalidateQueries(['/comment/v1', query.id]),
+  });
+
+  const handleSubmitComment = async (newComment: string) => {
+    await mutateEditComment(newComment);
+    setEditMode(false);
+  };
+
+  return (
+    <FeedCommentViewer
+      key={comment.id}
+      comment={comment}
+      Actions={[
+        <FeedActionButton onClick={() => setEditMode(true)}>수정</FeedActionButton>,
+        <FeedActionButton
+          onClick={() =>
+            overlay.open(({ isOpen, close }) => (
+              // eslint-disable-next-line prettier/prettier
+            <ConfirmModal isModalOpened={isOpen} message="댓글을 삭제하시겠습니까?" cancelButton="돌아가기" confirmButton="삭제하기" 
+                handleModalClose={close}
+                handleConfirm={() => {
+                  mutateDeleteComment(comment.id);
+                  close();
+                }}
+              />
+            ))
+          }
+        >
+          삭제
+        </FeedActionButton>,
+      ]}
+      Content={
+        editMode ? (
+          <FeedCommentEditor
+            defaultValue={comment.contents}
+            onCancel={() => setEditMode(false)}
+            onSubmit={handleSubmitComment}
+          />
+        ) : (
+          comment.contents
+        )
+      }
+      isMine={isMine}
+      onClickLike={onClickLike}
+    />
+  );
+}

--- a/src/components/feed/FeedCommentEditor/FeedCommentEditor.tsx
+++ b/src/components/feed/FeedCommentEditor/FeedCommentEditor.tsx
@@ -1,0 +1,65 @@
+import { useRef } from 'react';
+import { styled } from 'stitches.config';
+
+interface FeedCommentEditorProps {
+  defaultValue: string;
+  onCancel: () => void;
+  onSubmit: (newComment: string) => void;
+}
+
+export default function FeedCommentEditor({ defaultValue, onCancel, onSubmit }: FeedCommentEditorProps) {
+  const editorRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const handleSubmit = () => {
+    onSubmit(editorRef.current?.value || '');
+  };
+
+  return (
+    <EditorContainer>
+      <Editor ref={editorRef} defaultValue={defaultValue} />
+      <ButtonWrapper>
+        <CancelButton onClick={onCancel}>취소</CancelButton>
+        <SubmitButton onClick={handleSubmit}>수정</SubmitButton>
+      </ButtonWrapper>
+    </EditorContainer>
+  );
+}
+
+const EditorContainer = styled('div', {
+  padding: '12px 12px 14px 12px',
+  display: 'flex',
+  flexDirection: 'column',
+  borderRadius: '8px',
+  border: `1px solid $white`,
+  background: '$black100',
+});
+const Editor = styled('textarea', {
+  color: '$gray40',
+  fontStyle: 'B2',
+  background: 'transparent',
+  border: 'none',
+  outline: 'none',
+  resize: 'none',
+});
+const ButtonWrapper = styled('div', {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginTop: '4px',
+  gap: '6px',
+});
+const CancelButton = styled('button', {
+  padding: '4px 12px',
+  flexType: 'center',
+  borderRadius: '8px',
+  background: '$black60',
+  color: '$white100',
+  fontStyle: 'T5',
+});
+const SubmitButton = styled('button', {
+  padding: '4px 12px',
+  flexType: 'center',
+  background: '$white100',
+  borderRadius: '8px',
+  color: '$black100',
+  fontStyle: 'T5',
+});

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.stories.ts
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.stories.ts
@@ -22,6 +22,7 @@ export const Default: Story = {
       updatedDate: '2시간 전',
       user: {
         id: 1,
+        orgId: 10,
         name: '김지민',
         profileImage: 'https://mui.com/static/images/avatar/1.jpg',
       },

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -6,16 +6,18 @@ import { paths } from '@/__generated__/schema';
 import LikeIcon from 'public/assets/svg/like_in_comment.svg?v2';
 import LikeFillIcon from 'public/assets/svg/like_fill_in_comment.svg?v2';
 import { fromNow } from '@utils/dayjs';
+import React from 'react';
 
 interface FeedCommentViewerProps {
   // TODO: API 응답을 바로 interface에 꽂지 말고 모델 만들어서 사용하자
   comment: paths['/comment/v1']['get']['responses']['200']['content']['application/json']['data']['comments'][number];
   isMine?: boolean;
+  Content: React.ReactNode;
   Actions: React.ReactNode[];
   onClickLike?: () => void;
 }
 
-export default function FeedCommentViewer({ comment, isMine, Actions, onClickLike }: FeedCommentViewerProps) {
+export default function FeedCommentViewer({ comment, isMine, Content, Actions, onClickLike }: FeedCommentViewerProps) {
   return (
     <Container>
       <CommentHeader>
@@ -42,7 +44,7 @@ export default function FeedCommentViewer({ comment, isMine, Actions, onClickLik
       </CommentHeader>
 
       <CommentBody>
-        <CommentContents>{comment.contents}</CommentContents>
+        <CommentContents>{Content}</CommentContents>
         <CommentLikeWrapper>
           <LikeWrapper onClick={onClickLike}>
             <LikeIconWrapper>{comment.isLiked ? <LikeFillIcon /> : <LikeIcon />}</LikeIconWrapper>
@@ -92,7 +94,7 @@ const CommentBody = styled('div', {
   flexDirection: 'column',
   gap: '8px',
 });
-const CommentContents = styled('p', {
+const CommentContents = styled('div', {
   color: '$gray30',
   fontStyle: 'B2',
 });

--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -9,7 +9,7 @@ import { fromNow } from '@utils/dayjs';
 
 interface FeedCommentViewerProps {
   // TODO: API 응답을 바로 interface에 꽂지 말고 모델 만들어서 사용하자
-  comment: paths['/comment/v1']['get']['responses']['200']['content']['application/json']['comments'][number];
+  comment: paths['/comment/v1']['get']['responses']['200']['content']['application/json']['data']['comments'][number];
   isMine?: boolean;
   Actions: React.ReactNode[];
   onClickLike?: () => void;

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.stories.ts
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.stories.ts
@@ -15,6 +15,8 @@ type Story = StoryObj<typeof FeedPostViewer>;
 // More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Default: Story = {
   args: {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     post: {
       id: 1,
       title: '하트시그널 시즌 1부터 시즌 4까지 중에 가장 인기가 많았던 출연자는?',
@@ -28,6 +30,7 @@ export const Default: Story = {
       ],
       user: {
         id: 1,
+        orgId: 10,
         name: '김지민',
         profileImage: 'https://mui.com/static/images/avatar/1.jpg',
       },

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -14,7 +14,7 @@ dayjs.extend(relativeTime);
 dayjs.locale('ko');
 
 interface FeedPostViewerProps {
-  post: paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json'];
+  post: paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json']['data'];
   Actions: React.ReactNode[];
   CommentLikeSection: React.ReactNode;
   CommentList: React.ReactNode;

--- a/src/components/feed/Modal/FeedEditModal.tsx
+++ b/src/components/feed/Modal/FeedEditModal.tsx
@@ -66,7 +66,7 @@ function FeedEditModal({ isModalOpened, postId, handleModalClose }: EditModal) {
     formMethods.reset({
       title: postData.title,
       contents: postData.contents,
-      images: postData.images,
+      images: postData.images || [],
     });
   }, [formMethods, isModalOpened, postData]);
 

--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -49,9 +49,12 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
   };
 
   const renderedPosts = postsData?.pages.map(post => (
-    <Link href={`/post?id=${post.id}`} key={post.id}>
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    <Link href={`/post?id=${post!.id}`} key={post!.id}>
       <a>
-        <FeedItem {...post} />
+        {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
+        {/* @ts-ignore */}
+        <FeedItem {...post!} />
       </a>
     </Link>
   ));

--- a/src/hooks/useComment/useComment.ts
+++ b/src/hooks/useComment/useComment.ts
@@ -11,22 +11,12 @@ export default function useComment() {
     queryFn: ({ pageParam = 1 }) =>
       GET('/comment/v1', { params: { query: { postId: Number(query.id as string), page: pageParam } } }),
     getNextPageParam: lastPage => {
-      // TODO: 서버 스키마 변경 후 수정 필요
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       if (!lastPage.data?.data?.meta.hasNextPage) return;
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      return (lastPage?.data?.data?.meta.page as number) + 1;
+      return (lastPage.data.data.meta.page as number) + 1;
     },
     getPreviousPageParam: firstPage => {
-      // TODO: 서버 스키마 변경 후 수정 필요
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       if (!firstPage.data?.data?.meta.hasPreviousPage) return;
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      return (firstPage?.data?.data?.meta.page as number) - 1;
+      return (firstPage.data.data.meta.page as number) - 1;
     },
     enabled: !!query.id,
   });

--- a/src/hooks/useComment/useCommentMutation.ts
+++ b/src/hooks/useComment/useCommentMutation.ts
@@ -18,7 +18,7 @@ export default function useCommentMutation() {
 
       const previousComments = queryClient.getQueryData(['/comment/v1', query.id]);
 
-      type Comments = paths['/comment/v1']['get']['responses']['200']['content']['application/json'];
+      type Comments = paths['/comment/v1']['get']['responses']['200']['content']['application/json']['data'];
       queryClient.setQueryData<InfiniteData<{ data: { data: Comments } }>>(['/comment/v1', query.id], oldData => {
         const newData = produce(oldData, draft => {
           draft?.pages?.forEach(page => {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #477 

## 📋 작업 내용
- [x] #474 에서 OAS 스펙에 `{ data: {} }` 가 반영되어서 해당 OAS 로 codegen 된 타입들을 싹 수정해줬어요
- [x] 댓글 수정 기능을 구현하기 위해 `FeedCommentViewer` 에 `Content` props를 확장해서 editor를 합성할 수 있도록 했어요
- [x] 댓글 뷰어를 한 단계 더 추상화한 `FeedCommentContainer` 컴포넌트를 만들어서 필요한 컴포넌트들을 합성하도록 했어요.

## 📸 스크린샷



https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/67798643-e0b6-4312-80d4-78ecf9b8cd45


