### PR TITLE
댓글 작성 시간이 몇초 후 라고 표기되는 버그 수정 및 워딩 변경

### DIFF
--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -1,7 +1,18 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import updateLocale from 'dayjs/plugin/updateLocale';
 import 'dayjs/locale/ko';
+const localeList = dayjs.Ls;
+
 dayjs.extend(relativeTime);
 dayjs.locale('ko');
+dayjs.extend(updateLocale);
+dayjs.updateLocale('ko', {
+  relativeTime: {
+    ...localeList['ko'].relativeTime,
+    s: '방금',
+  },
+});
 
-export const fromNow = (date: string) => dayjs(date).fromNow();
+// NOTE: 댓글 작성 후 간헐적으로 작성 시간이 현재 시간보다 이후 시간으로 표기되는 이슈가 있어서 1초를 뺴준다.
+export const fromNow = (date: string) => dayjs(date).subtract(1, 's').fromNow();


### PR DESCRIPTION
## 🚩 관련 이슈
- close #481 

## 📋 작업 내용
- [x] 댓글 작성 이후 간헐적으로 `몇초 후` 라고 표기되는 버그 수정(주어진 시간으로부터 1초 빼고 이를 바탕으로 현재 시간과 비교해요)
- [x] 댓글 작성한지 얼마 안된 경우 `몇초 전` 이 아닌 `방금 전` 으로 표시하게끔 변경

## 📸 스크린샷
<img width="807" alt="Screenshot 2023-10-01 at 2 11 33 AM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/13644bf9-b6b9-40a1-a31b-38675d545534">
