### PR TITLE
피드 게시글 삭제 기능 추가

### DIFF
--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -70,6 +70,7 @@ export default function PostPage() {
     <div>
       <FeedPostViewer
         post={post}
+        isMine={post.user.id === me?.id}
         Actions={[
           <FeedActionButton>수정</FeedActionButton>,
           <FeedActionButton

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -53,9 +53,7 @@ export default function FeedPostViewer({
             </Menu.Button>
             <MenuItems>
               {Actions.map((Action, index) => (
-                <Menu.Item key={index}>
-                  <MenuItem>{Action}</MenuItem>
-                </Menu.Item>
+                <Menu.Item key={index}>{Action}</Menu.Item>
               ))}
             </MenuItems>
           </Menu>
@@ -207,25 +205,6 @@ const MenuItems = styled(Menu.Items, {
   position: 'absolute',
   top: 0,
   right: '100%', // TODO: design 체크 필요
-});
-const MenuItem = styled('button', {
-  display: 'flex',
-  width: '147px',
-  padding: '8px 16px',
-  justifyContent: 'center',
-  alignItems: 'center',
-  color: '$white100',
-  background: '$black80',
-  fontStyle: 'B3',
-  border: '1px solid $black40',
-  '&:first-child': {
-    borderRadius: '14px 14px 0 0',
-    borderBottom: 'none',
-  },
-  '&:last-child': {
-    borderRadius: '0 0 14px 14px ',
-    borderTop: 'none',
-  },
 });
 const CommentLikeWrapper = styled('div', {
   color: '$gray08',

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -15,6 +15,7 @@ dayjs.locale('ko');
 
 interface FeedPostViewerProps {
   post: paths['/post/v1/{postId}']['get']['responses']['200']['content']['application/json']['data'];
+  isMine?: boolean;
   Actions: React.ReactNode[];
   CommentLikeSection: React.ReactNode;
   CommentList: React.ReactNode;
@@ -23,6 +24,7 @@ interface FeedPostViewerProps {
 
 export default function FeedPostViewer({
   post,
+  isMine,
   Actions,
   CommentLikeSection,
   CommentList,
@@ -47,16 +49,18 @@ export default function FeedPostViewer({
               <UpdatedDate>{fromNow(post.updatedDate)}</UpdatedDate>
             </AuthorInfo>
           </AuthorWrapper>
-          <Menu as="div" style={{ position: 'relative' }}>
-            <Menu.Button>
-              <MenuIcon />
-            </Menu.Button>
-            <MenuItems>
-              {Actions.map((Action, index) => (
-                <Menu.Item key={index}>{Action}</Menu.Item>
-              ))}
-            </MenuItems>
-          </Menu>
+          {isMine && (
+            <Menu as="div" style={{ position: 'relative' }}>
+              <Menu.Button>
+                <MenuIcon />
+              </Menu.Button>
+              <MenuItems>
+                {Actions.map((Action, index) => (
+                  <Menu.Item key={index}>{Action}</Menu.Item>
+                ))}
+              </MenuItems>
+            </Menu>
+          )}
         </ContentHeader>
         <ContentBody>
           <Title>{post.title}</Title>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #478 

## 📋 작업 내용
- [x] 피드 게시글 삭제 기능을 추가했어요(삭제 이후엔 모임 화면으로 돌아감)
- [x] 피드 수정/삭제 메뉴 버튼을 내가 작성한 게시글에서만 보여주도록 해요

## 📸 스크린샷

https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/c7ff206e-a9c9-4f1d-bd3f-dff0e42e04b0

