### PR TITLE
아바타 컴포넌트 스타일 수정

### DIFF
--- a/src/components/avatar/AvatarGroup.tsx
+++ b/src/components/avatar/AvatarGroup.tsx
@@ -5,9 +5,7 @@ export default function AvatarGroup({ children }: PropsWithChildren) {
   return (
     <SContainer>
       {Children.map(children, (child, index) => (
-        <SAvatarWrapper key={index} style={{ transform: `translateX(-${33 * index}%)` }}>
-          {child}
-        </SAvatarWrapper>
+        <SAvatarWrapper key={index}>{child}</SAvatarWrapper>
       ))}
     </SContainer>
   );
@@ -18,6 +16,9 @@ const SContainer = styled('div', {
   alignItems: 'center',
 });
 const SAvatarWrapper = styled('div', {
+  '&:not(:first-child)': {
+    marginLeft: '-16px',
+  },
   '& > div': {
     border: '3px solid $black100',
   },


### PR DESCRIPTION
## 🚩 관련 이슈
- close #489 

## 📋 작업 내용
- [x] 아바타 그룹 컴포넌트 스타일을 수정했어요(`translateX` -> `margin`)

## 📸 스크린샷
<img width="501" alt="Screenshot 2023-10-01 at 9 07 49 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/fe222009-7e7e-4c6b-a437-7798bb122147">


<img width="388" alt="Screenshot 2023-10-01 at 9 11 32 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/3db0ab1a-99f9-4ffe-a0ec-3b1b115f633b">
