### PR TITLE
피드 상세 뷰 이미지 영역 패딩 수정

### DIFF
--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -159,7 +159,7 @@ const Contents = styled('p', {
   },
 });
 const ImageSection = styled('section', {
-  paddingRight: '25px',
+  paddingRight: '16px',
   marginTop: '20px',
   marginBottom: '12px',
   '@tablet': {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #493 

## 📋 작업 내용
- [x] 피드 상세 뷰 이미지 섹션 패딩 수정 

## 📸 스크린샷
| Before | After |
|----|-----|
| <img width="805" alt="Screenshot 2023-10-01 at 9 54 44 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/7b200432-cc5a-488a-a53e-a48748c6d04e">  |  <img width="801" alt="Screenshot 2023-10-01 at 9 54 29 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/22915a25-5e01-41b3-b81f-b1e2981f0ff6"> |