### PR TITLE
[이슈 04] 피드 리스트 뷰 MO와 PC 작성하기 CTA 버튼 색상 상이(주황색으로 통일)

### DIFF
--- a/src/components/page/meetingDetail/Feed/FeedPanel.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedPanel.tsx
@@ -137,7 +137,7 @@ const SCount = styled('span', {
 });
 
 const SButton = styled('button', {
-  backgroundColor: '$black40',
+  backgroundColor: '$orange100',
   fontStyle: 'H2',
   ml: '$48',
   color: '$white',
@@ -145,7 +145,6 @@ const SButton = styled('button', {
   borderRadius: '14px',
 
   '@tablet': {
-    backgroundColor: '$orange100',
     fontStyle: 'T5',
     ml: '$20',
     padding: '$6 $12',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #492 

## 📋 작업 내용
- [x] orange로 통일




## 📸 스크린샷
<img width="608" alt="스크린샷 2023-10-01 오후 10 05 21" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/26538967/bd5d75b3-5a40-4386-a870-9f707fefd38e">
<img width="440" alt="스크린샷 2023-10-01 오후 10 05 40" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/26538967/a1adadc5-e3d9-4028-8ae7-0d8d0c529684">
