### PR TITLE
피드 상세 뷰 댓글 입력 UI가 자리차지하는 스타일 이슈 수정

### DIFF
--- a/src/components/feed/FeedCommentInput/FeedCommentInput.tsx
+++ b/src/components/feed/FeedCommentInput/FeedCommentInput.tsx
@@ -36,6 +36,7 @@ const Container = styled('form', {
   gap: '16px',
 });
 const CommentInput = styled('input', {
+  minWidth: 0,
   width: '692px',
   padding: '14px 24px',
   borderRadius: '50px',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #494 

## 📋 작업 내용
- [x] 댓글 입력 UI의 최소 크기 지정으로 width가 줄어들 수 있도록 변경

## 📸 스크린샷
| Before | After |
|-----|-----|
|  <img width="358" alt="Screenshot 2023-10-01 at 10 23 50 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/6bd04879-717d-400a-8e82-53b2dbfd3d71">  |  <img width="358" alt="Screenshot 2023-10-01 at 10 23 35 PM" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/31213226/b34bfc74-f1e9-4840-ba2e-e06094d1be4a">  |
