### PR TITLE
[이슈 11] 모집 마감 태그 컬러 상이

### DIFF
--- a/src/components/page/meetingDetail/DetailHeader.tsx
+++ b/src/components/page/meetingDetail/DetailHeader.tsx
@@ -306,7 +306,7 @@ const SRecruitStatus = styled(Box, {
         color: '$black100',
       },
       2: {
-        backgroundColor: '$gray60',
+        backgroundColor: '$black60',
       },
     },
   },


### PR DESCRIPTION
## 🚩 관련 이슈
- close #497 

## 📋 작업 내용
- [x] 모집 마감 컬러 통일


## 📸 스크린샷
<img width="476" alt="스크린샷 2023-10-01 오후 10 22 32" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/26538967/d44a55ec-2bb2-47c1-bb1c-0ba63086b575">
<img width="418" alt="스크린샷 2023-10-01 오후 10 22 48" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/26538967/4b6b9086-7784-46db-918d-e301a39567e5">
