### PR TITLE
[이슈 20] 모바일 뷰 댓글 width 넘어갈 시 줄바꿈 안 되는 현상 해결

### DIFF
--- a/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
+++ b/src/components/feed/FeedCommentViewer/FeedCommentViewer.tsx
@@ -100,6 +100,7 @@ const CommentContents = styled('div', {
   color: '$gray30',
   fontStyle: 'B2',
   whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
 });
 const CommentLikeWrapper = styled('div', {
   flexType: 'verticalCenter',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #517 

## 📋 작업 내용
wordBreak 기본값이 Normal 인데 이 경우 영어는 줄바꿈이 안 된다고 해서 break-all 로 바꾸어주었습니다!

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
- 어떤 위험이나 우려가 발견되었는지
- 어떤 부분에 리뷰어가 집중해야 하는지
- 개발하면서 어떤 점이 궁금했는지

## 📸 스크린샷
![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/86764406/be693f38-29c5-4a40-8825-ee35405996ff)

