### PR TITLE
피드 상세 뷰 앰플리튜드 이벤트 로깅

### DIFF
--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -19,6 +19,7 @@ import { styled } from 'stitches.config';
 import FeedEditModal from '@components/feed/Modal/FeedEditModal';
 import { ampli } from '@/ampli';
 import { useQueryGetMeeting } from '@api/meeting/hooks';
+import React from 'react';
 
 export default function PostPage() {
   const overlay = useOverlay();
@@ -130,6 +131,13 @@ export default function PostPage() {
         CommentInput={<FeedCommentInput onSubmit={handleCreateComment} disabled={isCreatingComment} />}
         onClickImage={() => {
           ampli.clickFeeddetailLike({ crew_status: meeting?.approved });
+        }}
+        // NOTE: link 클릭하면 이동해버리기 때문에 이벤트 로깅이 잘 되지 않는다. 이를 방지하기 위해 로깅 이후에 이동하도록 하자.
+        onClickAuthor={async (e: React.MouseEvent<HTMLAnchorElement>) => {
+          const href = e.currentTarget.href;
+          e.preventDefault();
+          await ampli.clickFeeddetatilProfile({ crew_status: meeting?.approved }).promise;
+          window.location.assign(href);
         }}
       />
     </Container>

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -68,6 +68,11 @@ export default function PostPage() {
         !!comment
     );
 
+  const handleClickPostLike = () => {
+    ampli.clickFeeddetailLike({ crew_status: meeting?.approved });
+    togglePostLike();
+  };
+
   // TODO: loading 스켈레톤 UI가 있으면 좋을 듯
   if (!post) return <Loader />;
 
@@ -105,7 +110,7 @@ export default function PostPage() {
             isLiked={post.isLiked}
             commentCount={commentQuery.data?.pages[0].data?.data?.meta.itemCount || 0}
             likeCount={post.likeCount}
-            onClickLike={togglePostLike}
+            onClickLike={handleClickPostLike}
           />
         }
         CommentList={

--- a/src/components/feed/FeedCommentContainer/FeedCommentContainer.tsx
+++ b/src/components/feed/FeedCommentContainer/FeedCommentContainer.tsx
@@ -10,6 +10,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiV2 } from '@api/index';
 import FeedCommentEditor from '../FeedCommentEditor/FeedCommentEditor';
 import { parseTextToLink } from '@components/util/parseTextToLink';
+import { ampli } from '@/ampli';
+import { useQueryGetMeeting } from '@api/meeting/hooks';
 
 interface FeedCommentContainerProps {
   comment: paths['/comment/v1']['get']['responses']['200']['content']['application/json']['data']['comments'][number];
@@ -25,6 +27,8 @@ export default function FeedCommentContainer({ comment, isMine, isPosterComment,
   const { query } = useRouter();
   const overlay = useOverlay();
   const [editMode, setEditMode] = useState(false);
+
+  const { data: meeting } = useQueryGetMeeting({ params: { id: String(query.id) } });
 
   const { mutate: mutateDeleteComment } = useDeleteComment(query.id as string);
 
@@ -49,7 +53,11 @@ export default function FeedCommentContainer({ comment, isMine, isPosterComment,
           onClick={() =>
             overlay.open(({ isOpen, close }) => (
               // eslint-disable-next-line prettier/prettier
-            <ConfirmModal isModalOpened={isOpen} message="댓글을 삭제하시겠습니까?" cancelButton="돌아가기" confirmButton="삭제하기" 
+              <ConfirmModal
+                isModalOpened={isOpen}
+                message="댓글을 삭제하시겠습니까?"
+                cancelButton="돌아가기"
+                confirmButton="삭제하기"
                 handleModalClose={close}
                 handleConfirm={() => {
                   mutateDeleteComment(comment.id);
@@ -75,7 +83,10 @@ export default function FeedCommentContainer({ comment, isMine, isPosterComment,
       }
       isMine={isMine}
       isPosterComment={isPosterComment}
-      onClickLike={onClickLike}
+      onClickLike={() => {
+        ampli.clickCommentLike({ crew_status: meeting?.approved });
+        onClickLike();
+      }}
     />
   );
 }

--- a/src/components/feed/FeedCommentInput/FeedCommentInput.tsx
+++ b/src/components/feed/FeedCommentInput/FeedCommentInput.tsx
@@ -1,6 +1,11 @@
 import { styled } from 'stitches.config';
 import SendIcon from 'public/assets/svg/send.svg';
 import React, { useState } from 'react';
+import { useQueryGetMeeting } from '@api/meeting/hooks';
+import { useRouter } from 'next/router';
+import { ampli } from '@/ampli';
+import { useDisplay } from '@hooks/useDisplay';
+import { useQueryMyProfile } from '@api/user/hooks';
 
 interface FeedCommentInputProps {
   onSubmit: (comment: string) => Promise<void>;
@@ -8,7 +13,11 @@ interface FeedCommentInputProps {
 }
 
 export default function FeedCommentInput({ onSubmit, disabled }: FeedCommentInputProps) {
+  const { query } = useRouter();
+  const { isMobile } = useDisplay();
   const [comment, setComment] = useState('');
+  const { data: meeting } = useQueryGetMeeting({ params: { id: String(query.id) } });
+  const { data: me } = useQueryMyProfile();
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (e.target.value.length === 0) {
@@ -23,6 +32,11 @@ export default function FeedCommentInput({ onSubmit, disabled }: FeedCommentInpu
     event.preventDefault();
 
     if (!comment.trim()) return;
+    ampli.completedCommentPosting({
+      crew_status: meeting?.approved,
+      platform_type: isMobile ? 'MO' : 'PC',
+      user_id: Number(me?.orgId),
+    });
     onSubmit(comment).then(() => setComment(''));
   };
 

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -24,6 +24,7 @@ interface FeedPostViewerProps {
   CommentList: React.ReactNode;
   CommentInput: React.ReactNode;
   onClickImage?: () => void;
+  onClickAuthor?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export default function FeedPostViewer({
@@ -34,6 +35,7 @@ export default function FeedPostViewer({
   CommentList,
   CommentInput,
   onClickImage,
+  onClickAuthor,
 }: FeedPostViewerProps) {
   const overlay = useOverlay();
 
@@ -48,7 +50,10 @@ export default function FeedPostViewer({
     <Container>
       <ContentWrapper>
         <ContentHeader>
-          <AuthorWrapper href={`${playgroundURL}${playgroundLink.memberDetail(post.user.orgId)}`}>
+          <AuthorWrapper
+            href={`${playgroundURL}${playgroundLink.memberDetail(post.user.orgId)}`}
+            onClick={onClickAuthor}
+          >
             <SAvatar src={post.user.profileImage || ''} alt={post.user.name} />
             <AuthorInfo>
               <AuthorName>{post.user.name}</AuthorName>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #530 

## 📋 작업 내용
- [x] 피드 상세 뷰에서 좋아요 클릭 이벤트 로깅(`clickFeeddetailLike`)
- [x] 피드 상세 뷰에서 게시글 작성자 프로필 클릭 이벤트 로깅(`clickFeeddetatilProfile`)
