### PR TITLE
피드 작성 뷰 앰플리튜드 이벤트 로깅

### DIFF
--- a/src/components/feed/Modal/FeedCreateModal.tsx
+++ b/src/components/feed/Modal/FeedCreateModal.tsx
@@ -83,6 +83,7 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
       <SDialogWrapper>
         <FormProvider {...formMethods}>
           <FeedFormPresentation
+            userId={me?.id}
             groupInfo={{
               title: detailData?.title || '',
               imageUrl: detailData?.imageURL[THUMBNAIL_IMAGE_INDEX].url || '',

--- a/src/components/feed/Modal/FeedCreateModal.tsx
+++ b/src/components/feed/Modal/FeedCreateModal.tsx
@@ -15,6 +15,7 @@ import { useEffect } from 'react';
 import { THUMBNAIL_IMAGE_INDEX } from '@constants/index';
 import { ampli } from '@/ampli';
 import { useQueryMyProfile } from '@api/user/hooks';
+import { formatDate } from '@utils/dayjs';
 
 const DevTool = dynamic(() => import('@hookform/devtools').then(module => module.DevTool), {
   ssr: false,
@@ -30,6 +31,7 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
   const { data: me } = useQueryMyProfile();
   const exitModal = useModal();
   const submitModal = useModal();
+  const platform = window.innerWidth > 768 ? 'PC' : 'MO';
 
   const formMethods = useForm<FormType>({
     mode: 'onChange',
@@ -62,6 +64,7 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
   const onSubmit = async () => {
     const createFeedParameter = { ...formMethods.getValues(), meetingId: Number(meetingId) };
     await mutateCreateFeed(createFeedParameter);
+    ampli.completedFeedPosting({ user_id: me?.id, platform_type: platform, feed_upload: formatDate() });
   };
 
   useEffect(() => {
@@ -70,7 +73,7 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
 
   useEffect(() => {
     return () => {
-      ampli.completedFeedPostingCanceled({ user_id: me?.id, platform_type: window.innerWidth > 768 ? 'PC' : 'MO' });
+      ampli.completedFeedPostingCanceled({ user_id: me?.id, platform_type: platform });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/feed/Modal/FeedCreateModal.tsx
+++ b/src/components/feed/Modal/FeedCreateModal.tsx
@@ -64,7 +64,7 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
   const onSubmit = async () => {
     const createFeedParameter = { ...formMethods.getValues(), meetingId: Number(meetingId) };
     await mutateCreateFeed(createFeedParameter);
-    ampli.completedFeedPosting({ user_id: me?.id, platform_type: platform, feed_upload: formatDate() });
+    ampli.completedFeedPosting({ user_id: Number(me?.orgId), platform_type: platform, feed_upload: formatDate() });
   };
 
   useEffect(() => {
@@ -73,7 +73,7 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
 
   useEffect(() => {
     return () => {
-      ampli.completedFeedPostingCanceled({ user_id: me?.id, platform_type: platform });
+      ampli.completedFeedPostingCanceled({ user_id: Number(me?.orgId), platform_type: platform });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -83,7 +83,7 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
       <SDialogWrapper>
         <FormProvider {...formMethods}>
           <FeedFormPresentation
-            userId={me?.id}
+            userId={Number(me?.orgId)}
             groupInfo={{
               title: detailData?.title || '',
               imageUrl: detailData?.imageURL[THUMBNAIL_IMAGE_INDEX].url || '',

--- a/src/components/feed/Modal/FeedCreateModal.tsx
+++ b/src/components/feed/Modal/FeedCreateModal.tsx
@@ -13,6 +13,8 @@ import { useQueryGetMeeting } from '@api/meeting/hooks';
 import useModal from '@hooks/useModal';
 import { useEffect } from 'react';
 import { THUMBNAIL_IMAGE_INDEX } from '@constants/index';
+import { ampli } from '@/ampli';
+import { useQueryMyProfile } from '@api/user/hooks';
 
 const DevTool = dynamic(() => import('@hookform/devtools').then(module => module.DevTool), {
   ssr: false,
@@ -25,6 +27,7 @@ interface CreateModalProps extends ModalContainerProps {
 function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateModalProps) {
   const queryClient = useQueryClient();
   const { data: detailData } = useQueryGetMeeting({ params: { id: meetingId } });
+  const { data: me } = useQueryMyProfile();
   const exitModal = useModal();
   const submitModal = useModal();
 
@@ -64,6 +67,13 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
   useEffect(() => {
     formMethods.reset();
   }, [formMethods, isModalOpened]);
+
+  useEffect(() => {
+    return () => {
+      ampli.completedFeedPostingCanceled({ user_id: me?.id, platform_type: window.innerWidth > 768 ? 'PC' : 'MO' });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <ModalContainer isModalOpened={isModalOpened} handleModalClose={exitModal.handleModalOpen}>

--- a/src/components/feed/Modal/FeedEditModal.tsx
+++ b/src/components/feed/Modal/FeedEditModal.tsx
@@ -13,6 +13,7 @@ import { useEffect } from 'react';
 import { THUMBNAIL_IMAGE_INDEX } from '@constants/index';
 import { useQueryGetPost } from '@api/post/hooks';
 import { editPost } from '@api/post';
+import { useQueryMyProfile } from '@api/user/hooks';
 
 const DevTool = dynamic(() => import('@hookform/devtools').then(module => module.DevTool), {
   ssr: false,
@@ -27,6 +28,7 @@ function FeedEditModal({ isModalOpened, postId, handleModalClose }: EditModal) {
   const { data: postData } = useQueryGetPost(postId);
   const exitModal = useModal();
   const submitModal = useModal();
+  const { data: me } = useQueryMyProfile();
 
   const formMethods = useForm<FormType>({
     mode: 'onChange',
@@ -75,6 +77,7 @@ function FeedEditModal({ isModalOpened, postId, handleModalClose }: EditModal) {
       <SDialogWrapper>
         <FormProvider {...formMethods}>
           <FeedFormPresentation
+            userId={me?.id}
             groupInfo={{
               title: postData?.meeting?.title || '',
               imageUrl: postData?.meeting?.imageURL[THUMBNAIL_IMAGE_INDEX].url || '',

--- a/src/components/feed/Modal/FeedEditModal.tsx
+++ b/src/components/feed/Modal/FeedEditModal.tsx
@@ -77,7 +77,7 @@ function FeedEditModal({ isModalOpened, postId, handleModalClose }: EditModal) {
       <SDialogWrapper>
         <FormProvider {...formMethods}>
           <FeedFormPresentation
-            userId={me?.id}
+            userId={Number(me?.orgId)}
             groupInfo={{
               title: postData?.meeting?.title || '',
               imageUrl: postData?.meeting?.imageURL[THUMBNAIL_IMAGE_INDEX].url || '',

--- a/src/components/feed/Modal/FeedFormPresentation.tsx
+++ b/src/components/feed/Modal/FeedFormPresentation.tsx
@@ -14,6 +14,7 @@ import FormController from '@components/form/FormController';
 import { ERROR_MESSAGE } from './feedSchema';
 import useToast from '@hooks/useToast';
 import { FORM_TITLE_MAX_LENGTH } from '@constants/feed';
+import { ampli } from '@/ampli';
 
 interface GroupInfo {
   title: string;
@@ -22,6 +23,7 @@ interface GroupInfo {
 }
 
 interface PresentationProps {
+  userId?: number;
   groupInfo: GroupInfo;
   title: string;
   handleModalClose: () => void;
@@ -35,6 +37,7 @@ interface FileChangeHandler {
 }
 
 function FeedFormPresentation({
+  userId,
   groupInfo,
   title,
   handleModalClose,
@@ -102,6 +105,7 @@ function FeedFormPresentation({
         onChange([...imageUrls, ...urls]);
       }
       setTextareaHeightChangeFlag(flag => !flag);
+      ampli.attachFeedPhoto({ user_id: userId, platform_type: window.innerWidth > 768 ? 'PC' : 'MO' });
     };
 
   const uploadFile = async (file: File) => {

--- a/src/utils/dayjs.ts
+++ b/src/utils/dayjs.ts
@@ -18,3 +18,5 @@ dayjs.updateLocale('ko', {
 
 // NOTE: 댓글 작성 후 간헐적으로 작성 시간이 현재 시간보다 이후 시간으로 표기되는 이슈가 있어서 1초를 뺴준다.
 export const fromNow = (date: string) => dayjs(date).subtract(1, 's').fromNow();
+
+export const formatDate = (date?: string) => dayjs(date).format('YYYY-MM-DD HH:mm:ss');


### PR DESCRIPTION
## 🚩 관련 이슈
- close #534 

## 📋 작업 내용
- [x] 사진 업로드 이벤트 로깅(`attachFeedPhoto`)
- [x] 피드 작성 완료 이벤트 로깅(`completedFeedPosting`)
- [x] 피드 작성 중 이탈 이벤트 로깅(`completedFeedPostingCanceled`)

## 📌 PR Point
- 현재 피드 작성 중 이탈 이벤트를 모달이 닫힐 때 로깅하도록 했는데, 현재로선 작성을 정상적으로 완료 후 닫힐때도 로깅됨. 이 이벤트를 이탈을 보기 위해 찍는 것이라면 '피드 작성 버튼' 클릭 이후 또는 작성 모달 조회 이후 작성 완료 이벤트가 얼마나 발생했는지를 보면 로깅하지 않아도 될 듯?
