### PR TITLE
[이슈 25] 피드 리스트에서 좋아요 클릭 시 다른 곳에서 산발적으로 아바타 컴포넌트가 바뀌는 이슈

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties } from 'react';
 import { styled } from 'stitches.config';
 import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
+import { getResizedImage } from '@utils/image';
 
 interface AvatarProps {
   src?: string;
@@ -14,7 +15,7 @@ export default function Avatar({ src, alt, sx, className, Overlay }: AvatarProps
   return (
     <SContainer style={sx} className={className}>
       {Overlay}
-      {src ? <SImage src={src} alt={alt} /> : <ProfileDefaultIcon />}
+      {src ? <SImage src={getResizedImage(src, 32)} alt={alt} /> : <ProfileDefaultIcon />}
     </SContainer>
   );
 }

--- a/src/components/page/meetingDetail/Feed/FeedItem.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem.tsx
@@ -46,7 +46,6 @@ const FeedItem = (post: FeedItemProps) => {
     e.preventDefault();
     mutate();
   };
-
   return (
     <SFeedItem>
       <STop>
@@ -73,17 +72,20 @@ const FeedItem = (post: FeedItemProps) => {
         <Flex align="center">
           {commenterThumbnails && (
             <AvatarGroup>
-              {commenterThumbnails.slice(0, AVATAR_MAX_LENGTH).map((thumbnail, index) => (
-                <Avatar
-                  key={`${thumbnail}-${index}`}
-                  src={thumbnail}
-                  alt=""
-                  Overlay={
-                    commenterThumbnails.length > AVATAR_MAX_LENGTH &&
-                    index === AVATAR_MAX_LENGTH - 1 && <SOverlay>+</SOverlay>
-                  }
-                />
-              ))}
+              {[...commenterThumbnails]
+                ?.sort()
+                .slice(0, AVATAR_MAX_LENGTH)
+                .map((thumbnail, index) => (
+                  <Avatar
+                    key={`${thumbnail}-${index}`}
+                    src={thumbnail}
+                    alt=""
+                    Overlay={
+                      commenterThumbnails.length > AVATAR_MAX_LENGTH &&
+                      index === AVATAR_MAX_LENGTH - 1 && <SOverlay>+</SOverlay>
+                    }
+                  />
+                ))}
             </AvatarGroup>
           )}
           <SCommentWrapper hasComment={commentCount > 0}>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #537 

## 📋 작업 내용
- [x] commet thumbnail을 sorting하는 로직추가
- [x] 아바타 컴포넌트에 getResizedImage 추가

## 📌 PR Point
- 좋아요시 전체 피드가 리랜더링 되는데, 아바타 이미지가 너무 커서 깜빡이는게 너무 큼. 그래서 아바타 컨포넌트에 getResizedImage 추가해서 조정

## 📸 스크린샷
