### PR TITLE
피드 상세뷰 가로 스크롤 수정

### DIFF
--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -75,7 +75,7 @@ export default function FeedPostViewer({
         <ContentBody>
           <Title>{post.title}</Title>
           <Contents>{parseTextToLink(post.contents)}</Contents>
-          {post.images && (
+          {post.images && post.images.length > 0 && (
             <ImageSection>
               {post.images.length === 1 ? (
                 <BigImage src={post.images[0]} onClick={handleClickImage(post.images, 0)} />
@@ -196,8 +196,13 @@ const ImageListWrapper = styled('div', {
   gap: '8px',
   '@tablet': {
     display: 'flex',
-    overflow: 'scroll',
     gap: '6px',
+    overflowX: 'scroll',
+    '-ms-overflow-style': 'none',
+    scrollbarWidth: 'none',
+    '&::-webkit-scrollbar': {
+      display: 'none',
+    },
   },
 });
 const ImageListItem = styled('img', {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #470 

## 📋 작업 내용
- [x] 이미지 없을 때도 생기는 가로 스크롤 제거
- [x] 이미지 여러 장일 때 생기는 스크롤바 안 보이도록 숨기기

## 📸 스크린샷
|Before|After|
|:-:|:-:|
|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/a27bf1d5-aada-412e-b4eb-55601c8bab3f)|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/d1cab83b-fedc-40a5-b315-742da586a1e6)|