### PR TITLE
모임 상세 이미지 크기 이슈

### DIFF
--- a/src/components/modal/ImageCarouselModal.tsx
+++ b/src/components/modal/ImageCarouselModal.tsx
@@ -32,9 +32,7 @@ export default function ImageCarouselModal({ isOpen, close, images, startIndex =
         <Container>
           {/* top 고정 요소 */}
           {/* eslint-disable-next-line prettier/prettier */}
-          <Counter>
-            {currentIndex} / {images.length}
-          </Counter>
+          <Counter>{currentIndex} / {images.length}</Counter>
           <CloseButton onClick={close}>
             <CloseIcon />
           </CloseButton>

--- a/src/components/modal/ImageCarouselModal.tsx
+++ b/src/components/modal/ImageCarouselModal.tsx
@@ -32,7 +32,9 @@ export default function ImageCarouselModal({ isOpen, close, images, startIndex =
         <Container>
           {/* top 고정 요소 */}
           {/* eslint-disable-next-line prettier/prettier */}
-          <Counter>{currentIndex} / {images.length}</Counter>
+          <Counter>
+            {currentIndex} / {images.length}
+          </Counter>
           <CloseButton onClick={close}>
             <CloseIcon />
           </CloseButton>
@@ -125,7 +127,7 @@ const Image = styled('img', {
   maxWidth: '100%',
   height: '100%',
   maxHeight: '100vh',
-  objectFit: 'cover',
+  objectFit: 'contain',
 });
 const ArrowButton = styled('button', {
   flexType: 'center',

--- a/src/components/modal/ImageCarouselModal.tsx
+++ b/src/components/modal/ImageCarouselModal.tsx
@@ -107,9 +107,10 @@ const CarouselContainer = styled('div', {
 });
 const CarouselScrollContainer = styled('div', {
   display: 'flex',
+  alignItems: 'center',
   maxWidth: '1280px',
   height: '100%',
-  maxHeight: '600px',
+  maxHeight: '100vh',
 });
 const CarouselItem = styled('div', {
   flexType: 'center',
@@ -117,11 +118,14 @@ const CarouselItem = styled('div', {
   height: '100%',
   flex: '0 0 100%',
   minWidth: 0,
+  overflow: 'hidden',
 });
 const Image = styled('img', {
-  width: '100%',
+  width: 'fit-content',
+  maxWidth: '100%',
   height: '100%',
-  objectFit: 'contain',
+  maxHeight: '100vh',
+  objectFit: 'cover',
 });
 const ArrowButton = styled('button', {
   flexType: 'center',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #564 

## 📋 작업 내용
- [x] 데스크탑 환경에서도 이미지가 잘리지 않도록 수정

## 📌 PR Point
- maxHeight가 600px로 지정되어 생기는 문제라 이 부분을 수정했습니다.

## 📸 스크린샷
|Before|After|
|:-:|:-:|
|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/9936a92f-708c-4210-9c11-7e33b961eb8d)|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/291889b5-2b93-455b-b260-b5c270e690f3)|