### PR TITLE
내가 속한 모임 없음 모달 UI 작성

### DIFF
--- a/src/components/modal/FloatingButtonModal.tsx
+++ b/src/components/modal/FloatingButtonModal.tsx
@@ -28,7 +28,7 @@ const fadeIn = keyframes({
 });
 
 const fadeOut = keyframes({
-  from: { opacity: '1', transform: 'translateY(0px)' },
+  from: { transform: 'translateY(0px)' },
   to: { opacity: '0', transform: 'translateY(7px)' },
 });
 

--- a/src/components/modal/FloatingButtonModal.tsx
+++ b/src/components/modal/FloatingButtonModal.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
-import GroupIcon from '../../../public/assets/svg/floating_button_group_icon.svg';
+import { useState } from 'react';
+import { keyframes, styled } from 'stitches.config';
 import FeedIcon from '../../../public/assets/svg/floating_button_feed_icon.svg';
-import { styled } from 'stitches.config';
-import { keyframes } from 'stitches.config';
+import GroupIcon from '../../../public/assets/svg/floating_button_group_icon.svg';
 import NoJoinedGroupModal from './NoJoinedGroupModal';
 
 const FloatingButtonModal = (props: { isActive: boolean }) => {
@@ -20,7 +19,7 @@ const FloatingButtonModal = (props: { isActive: boolean }) => {
           피드 작성
         </Button>
       </Container>
-      {isCreateGroupClicked && <NoJoinedGroupModal></NoJoinedGroupModal>}
+      {isCreateGroupClicked && <NoJoinedGroupModal />}
     </>
   );
 };

--- a/src/components/modal/FloatingButtonModal.tsx
+++ b/src/components/modal/FloatingButtonModal.tsx
@@ -1,22 +1,27 @@
-import React from 'react';
+import React, { useState } from 'react';
 import GroupIcon from '../../../public/assets/svg/floating_button_group_icon.svg';
 import FeedIcon from '../../../public/assets/svg/floating_button_feed_icon.svg';
 import { styled } from 'stitches.config';
 import { keyframes } from 'stitches.config';
+import NoJoinedGroupModal from './NoJoinedGroupModal';
 
 const FloatingButtonModal = (props: { isActive: boolean }) => {
   const { isActive } = props;
+  const [isCreateGroupClicked, setIsCreateGroupClicked] = useState(false);
   return (
-    <Container isActive={isActive}>
-      <Button>
-        <GroupIcon style={{ marginRight: '4px' }} />
-        모임 개설
-      </Button>
-      <Button>
-        <FeedIcon style={{ marginRight: '4px' }} />
-        피드 작성
-      </Button>
-    </Container>
+    <>
+      <Container isActive={isActive}>
+        <Button onClick={() => setIsCreateGroupClicked(true)}>
+          <GroupIcon style={{ marginRight: '4px' }} />
+          모임 개설
+        </Button>
+        <Button>
+          <FeedIcon style={{ marginRight: '4px' }} />
+          피드 작성
+        </Button>
+      </Container>
+      {isCreateGroupClicked && <NoJoinedGroupModal></NoJoinedGroupModal>}
+    </>
   );
 };
 

--- a/src/components/modal/FloatingButtonModal.tsx
+++ b/src/components/modal/FloatingButtonModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useOverlay } from '@hooks/useOverlay/Index';
 import { keyframes, styled } from 'stitches.config';
 import FeedIcon from '../../../public/assets/svg/floating_button_feed_icon.svg';
 import GroupIcon from '../../../public/assets/svg/floating_button_group_icon.svg';
@@ -6,11 +6,15 @@ import NoJoinedGroupModal from './NoJoinedGroupModal';
 
 const FloatingButtonModal = (props: { isActive: boolean }) => {
   const { isActive } = props;
-  const [isCreateGroupClicked, setIsCreateGroupClicked] = useState(false);
+
+  const overlay = useOverlay();
+  const handleNoJoinedModalClose = () =>
+    overlay.open(({ isOpen, close }) => <NoJoinedGroupModal isModalOpened={isOpen} handleModalClose={close} />);
+
   return (
     <>
       <Container isActive={isActive}>
-        <Button onClick={() => setIsCreateGroupClicked(true)}>
+        <Button onClick={handleNoJoinedModalClose}>
           <GroupIcon style={{ marginRight: '4px' }} />
           모임 개설
         </Button>
@@ -19,7 +23,6 @@ const FloatingButtonModal = (props: { isActive: boolean }) => {
           피드 작성
         </Button>
       </Container>
-      {isCreateGroupClicked && <NoJoinedGroupModal />}
     </>
   );
 };

--- a/src/components/modal/NoJoinedGroupModal.tsx
+++ b/src/components/modal/NoJoinedGroupModal.tsx
@@ -1,27 +1,41 @@
-import { useRouter } from 'next/router';
-import React from 'react';
+import { Dialog } from '@headlessui/react';
+import Link from 'next/link';
 import { styled } from 'stitches.config';
+import ModalBackground from './ModalBackground';
+import { ModalContainerProps } from './ModalContainer';
 
-const NoJoinedGroupModal = () => {
-  const router = useRouter();
+const NoJoinedGroupModal = ({ isModalOpened, handleModalClose }: ModalContainerProps) => {
   return (
-    <Container>
-      <div>
-        <Title>내가 가입한 모임이 없어요</Title>
-        <Content>가입한 모임이 있어야만 피드를 작성할 수 있어요. 모임을 찾아볼까요?</Content>
-      </div>
-      <div>
-        <FindGroupButton onClick={() => router.push('/list')}>모임 찾기</FindGroupButton>
-      </div>
-    </Container>
+    <Dialog open={isModalOpened} onClose={handleModalClose}>
+      <ModalBackground
+        onClick={handleModalClose}
+        css={{
+          zIndex: '$3',
+        }}
+      />{' '}
+      <Dialog.Panel>
+        <Container>
+          <div>
+            <Title>내가 가입한 모임이 없어요</Title>
+            <Content>가입한 모임이 있어야만 피드를 작성할 수 있어요. 모임을 찾아볼까요?</Content>
+          </div>
+          <div>
+            <Link href="/list">
+              <FindGroupButton>모임 찾기</FindGroupButton>
+            </Link>
+          </div>
+        </Container>
+      </Dialog.Panel>
+    </Dialog>
   );
 };
 
 export default NoJoinedGroupModal;
 
 const Container = styled('div', {
-  width: '400px',
-  height: '222px',
+  width: '80%',
+  maxWidth: '500px',
+  minHeight: '222px',
   borderRadius: '14px',
   backgroundColor: '$gray800',
   position: 'fixed',
@@ -32,20 +46,23 @@ const Container = styled('div', {
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
+  zIndex: '$4',
 });
 
 const Title = styled('div', {
   fontStyle: 'T2',
   mb: '$12',
+  color: '$gray10',
 });
 
 const Content = styled('div', {
   fontSize: '16px',
   fontWeight: '400',
   lineHeight: '26px',
+  color: '$gray100',
 });
 
-const FindGroupButton = styled('button', {
+const FindGroupButton = styled('p', {
   width: '92px',
   height: '44px',
   borderRadius: '10px',
@@ -56,4 +73,5 @@ const FindGroupButton = styled('button', {
   fontWeight: '600',
   lineHeight: '18px',
   float: 'right ',
+  cursor: 'pointer',
 });

--- a/src/components/modal/NoJoinedGroupModal.tsx
+++ b/src/components/modal/NoJoinedGroupModal.tsx
@@ -1,0 +1,59 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+import { styled } from 'stitches.config';
+
+const NoJoinedGroupModal = () => {
+  const router = useRouter();
+  return (
+    <Container>
+      <div>
+        <Title>내가 가입한 모임이 없어요</Title>
+        <Content>가입한 모임이 있어야만 피드를 작성할 수 있어요. 모임을 찾아볼까요?</Content>
+      </div>
+      <div>
+        <FindGroupButton onClick={() => router.push('/list')}>모임 찾기</FindGroupButton>
+      </div>
+    </Container>
+  );
+};
+
+export default NoJoinedGroupModal;
+
+const Container = styled('div', {
+  width: '400px',
+  height: '222px',
+  borderRadius: '14px',
+  backgroundColor: '$gray800',
+  position: 'fixed',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  padding: '24px',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+});
+
+const Title = styled('div', {
+  fontStyle: 'T2',
+  mb: '$12',
+});
+
+const Content = styled('div', {
+  fontSize: '16px',
+  fontWeight: '400',
+  lineHeight: '26px',
+});
+
+const FindGroupButton = styled('button', {
+  width: '92px',
+  height: '44px',
+  borderRadius: '10px',
+  backgroundColor: '$white',
+  color: '$black',
+  flexType: 'center',
+  fontSize: '14px',
+  fontWeight: '600',
+  lineHeight: '18px',
+  float: 'right ',
+});


### PR DESCRIPTION
## 🚩 관련 이슈
- close #611 
## 📋 작업 내용
- [x] 모달 UI 작업 => 모임 찾기 버튼 누르면 '/group' 으로 이동하고, 플로팅에서 모임 개설 클릭 시 모달 창 뜨도록 구현해 두었어요!! :)
- [x] 플로팅 버튼에서 옵션 창이 첫 렌더링 시 잠깐 보이는 이슈가 있었는데, fadeout 애니메이션의 from 에서 opacity 를 1 로 고정해 두어서 발생했던 이슈였습니당..!!
## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
- 어떤 위험이나 우려가 발견되었는지
- 어떤 부분에 리뷰어가 집중해야 하는지
- 개발하면서 어떤 점이 궁금했는지

## 📸 스크린샷
<img width="1202" alt="image" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/86764406/54b8b264-00c7-4547-8479-d524073aa23a">

