### PR TITLE
피드 아이템 컴포넌트 확장(좋아요 버튼 합성, onClick props 추가)

### DIFF
--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -25,12 +25,12 @@ export const useInfinitePosts = (take: number, meetingId: number) => {
   return { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading };
 };
 
-export const useMutationUpdateLike = (take: number, meetingId: number, postId: number) => {
+export const useMutationUpdateLike = (take: number, meetingId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => postLike(String(postId)),
-    onMutate: async () => {
+    mutationFn: (postId: number) => postLike(String(postId)),
+    onMutate: async postId => {
       await queryClient.cancelQueries(['getPosts', take, meetingId]);
 
       type Post = paths['/post/v1']['get']['responses']['200']['content']['application/json']['data'];

--- a/src/components/button/LikeButton.tsx
+++ b/src/components/button/LikeButton.tsx
@@ -1,0 +1,42 @@
+import LikeActiveIcon from '@assets/svg/like_active.svg';
+import LikeDefaultIcon from '@assets/svg/like_default.svg';
+import { LIKE_MAX_COUNT } from '@constants/feed';
+import { styled } from 'stitches.config';
+
+interface LikeButtonProps {
+  isLiked: boolean;
+  likeCount: number;
+  onClickLike: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export default function LikeButton({ isLiked, likeCount, onClickLike }: LikeButtonProps) {
+  const formattedLikeCount = likeCount > LIKE_MAX_COUNT ? `${LIKE_MAX_COUNT}+` : likeCount;
+
+  return (
+    <SLikeButton like={isLiked} onClick={onClickLike}>
+      {isLiked ? <LikeActiveIcon /> : <LikeDefaultIcon />}
+      {formattedLikeCount}
+    </SLikeButton>
+  );
+}
+
+const SLikeButton = styled('button', {
+  display: 'flex',
+  alignItems: 'center',
+  fontStyle: 'H5',
+
+  variants: {
+    like: {
+      true: {
+        color: '$red',
+      },
+      false: {
+        color: '$gray10',
+      },
+    },
+  },
+
+  '& > svg': {
+    mr: '$6',
+  },
+});


### PR DESCRIPTION
## 🚩 관련 이슈
- close #615 

## 📋 작업 내용
- [x] 피드 아이템 컴포넌트가 피드 패널 뿐만 아니라 게시글 상세페이지에서도 사용되기 때문에 제너럴하게 사용될 수 있도록 각종 로직(router, ampli)과 디커풀 시켰어요
  - [x] 좋아요 버튼을 합성할 수 있게 `LikeButton` props를 추가했어요
  - [x] 아이템 클릭 로직도 사용하는 곳에서 정의할 수 있도록 `onClick` props를 추가했어요

