### PR TITLE
피드 게시글 상세페이지에서는 스크롤 복원 안되도록 처리

### DIFF
--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,11 +1,15 @@
 import { NextRouter, useRouter } from 'next/router';
 import { useEffect } from 'react';
 
+const blacklist = ['/post'];
+
 export default function useScrollRestoration() {
   const router = useRouter();
 
   useEffect(() => {
     if (!('scrollRestoration' in window.history)) return;
+
+    if (blacklist.includes(router.pathname)) return;
 
     window.history.scrollRestoration = 'manual';
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #633 

## 📋 작업 내용
- [x] 피드 게시글 상세페이지에서 스크롤 복원 안되도록 처리
