### PR TITLE
피드 상세 리스트 뷰 내 카드 width를 핸드오프와 동일하게 수정

### DIFF
--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -324,4 +324,7 @@ const FeedList = styled('ul', {
   display: 'flex',
   flexDirection: 'column',
   gap: '24px',
+  a: {
+    width: '$380',
+  },
 });


### PR DESCRIPTION
## 🚩 관련 이슈
- close #659 

## 📋 작업 내용
- [x] 피드 상세 리스트 뷰 내 카드 width를 핸드오프와 동일하게 수정

## 📸 스크린샷
![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/33294480-e0fc-47b6-a505-18f305b0e12d)
