### PR TITLE
필요한 부분에 getResizedImage 적용

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import { useInfinitePosts, useMutationUpdateLike } from '@api/post/hooks';
 import LikeButton from '@components/button/LikeButton';
 import FeedItem from '@components/page/meetingDetail/Feed/FeedItem';
 import MeetingInfo from '@components/page/meetingDetail/Feed/FeedItem/MeetingInfo';
+import DesktopFeedListSkeleton from '@components/page/meetingDetail/Feed/Skeleton/DesktopFeedListSkeleton';
 import MobileFeedListSkeleton from '@components/page/meetingDetail/Feed/Skeleton/MobileFeedListSkeleton';
 import FloatingButton from '@components/page/postList/FloatingButton';
 import { TabList } from '@components/tabList/TabList';
@@ -22,7 +23,7 @@ const Home: NextPage = () => {
   const router = useRouter();
   const { ref, inView } = useInView();
 
-  const { data: postsData, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfinitePosts(TAKE_COUNT);
+  const { data: postsData, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfinitePosts(TAKE_COUNT);
 
   const { mutate: mutateLikeInAllPost } = useMutationUpdateLike(TAKE_COUNT);
 
@@ -97,6 +98,9 @@ const Home: NextPage = () => {
             </Link>
           </TabList>
         </Flex>
+
+        {isLoading &&
+          (isTablet ? <MobileFeedListSkeleton count={3} /> : <DesktopFeedListSkeleton row={3} column={3} />)}
 
         {isTablet ? (
           <SMobileContainer>{renderedPosts}</SMobileContainer>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -122,7 +122,7 @@ const Home: NextPage = () => {
 export default Home;
 
 const SDesktopContainer = styled(MasonryInfiniteGrid, {
-  marginTop: '$40',
+  margin: '$40 0',
   a: {
     width: 'calc(calc(100% - 60px) / 3)',
   },
@@ -131,7 +131,7 @@ const SDesktopContainer = styled(MasonryInfiniteGrid, {
 const SMobileContainer = styled('div', {
   display: 'flex',
   flexDirection: 'column',
-  marginTop: 0,
+  margin: 0,
   '& a:not(:first-child)::before': {
     content: '',
     display: 'none',

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -4,7 +4,7 @@ import { produce } from 'immer';
 import { deleteComment, getPost, getPosts, postLike } from '.';
 
 export const useInfinitePosts = (take: number, meetingId?: number, enabled?: boolean) => {
-  const { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
+  return useInfiniteQuery({
     queryKey: ['getPosts', take, meetingId],
     queryFn: ({ pageParam = 1 }) => getPosts(pageParam, take, meetingId),
     getNextPageParam: (lastPage, allPages) => {
@@ -21,8 +21,6 @@ export const useInfinitePosts = (take: number, meetingId?: number, enabled?: boo
       total: data.pages[0]?.data.meta.itemCount,
     }),
   });
-
-  return { data, hasNextPage, fetchNextPage, isFetchingNextPage, isLoading };
 };
 
 export const useMutationUpdateLike = (take: number, meetingId?: number) => {

--- a/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
+++ b/src/components/feed/FeedPostViewer/FeedPostViewer.tsx
@@ -7,6 +7,7 @@ import ArrowIcon from '@assets/svg/arrow_card.svg';
 import { styled } from 'stitches.config';
 import { useOverlay } from '@hooks/useOverlay/Index';
 import ImageCarouselModal from '@components/modal/ImageCarouselModal';
+import { getResizedImage } from '@utils/image';
 import { fromNow } from '@utils/dayjs';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -110,7 +111,7 @@ export default function FeedPostViewer({
         </ContentBody>
         <Link href={`/detail?id=${post.meeting.id}`} passHref>
           <GroupButton>
-            <GroupThumbnail src={post.meeting.imageURL[0].url} alt="" />
+            <GroupThumbnail src={getResizedImage(post.meeting.imageURL[0].url, 88)} alt="" />
             <GroupInformation>
               <div>
                 <span>{post.meeting.category}</span>
@@ -340,7 +341,7 @@ const ViewCount = styled('span', {
 const MenuItems = styled(Menu.Items, {
   position: 'absolute',
   top: 0,
-  right: '100%', // TODO: design 체크 필요
+  right: '100%',
 });
 const CommentLikeWrapper = styled('div', {
   color: '$gray08',
@@ -370,5 +371,9 @@ const SAvatar = styled(Avatar, {
   '@tablet': {
     width: '40px',
     height: '40px',
+  },
+  svg: {
+    width: '44px',
+    height: '44px',
   },
 });

--- a/src/components/page/meetingDetail/Feed/FeedItem/index.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem/index.tsx
@@ -12,6 +12,7 @@ import { playgroundLink } from '@sopt-makers/playground-common';
 import { fromNow } from '@utils/dayjs';
 import truncateText from '@utils/truncateText';
 import { useRouter } from 'next/router';
+import { getResizedImage } from '@utils/image';
 
 interface PostProps {
   id: number;
@@ -50,7 +51,11 @@ const FeedItem = ({ post, HeaderSection, LikeButton, onClick }: FeedItemProps) =
             }}
           >
             <SProfileImageWrapper>
-              {user.profileImage ? <SProfileImage src={user.profileImage} alt="" /> : <ProfileDefaultIcon />}
+              {user.profileImage ? (
+                <SProfileImage src={getResizedImage(user.profileImage, 32)} alt="" />
+              ) : (
+                <ProfileDefaultIcon />
+              )}
             </SProfileImageWrapper>
             <SName>{user.name}</SName>
           </SProfileButton>
@@ -63,7 +68,7 @@ const FeedItem = ({ post, HeaderSection, LikeButton, onClick }: FeedItemProps) =
       <SContent>{truncateText(contents, CARD_CONTENT_MAX_LENGTH)}</SContent>
       {images && images[THUMBNAIL_IMAGE_INDEX] && (
         <SThumbnailWrapper>
-          <SThumbnail src={images[THUMBNAIL_IMAGE_INDEX]} alt="" />
+          <SThumbnail src={getResizedImage(images[THUMBNAIL_IMAGE_INDEX], 340)} alt="" />
           {images.length > 1 && <SThumbnailCount>+{images.length - 1}</SThumbnailCount>}
         </SThumbnailWrapper>
       )}

--- a/src/components/page/meetingDetail/Feed/Skeleton/DesktopFeedListSkeleton.tsx
+++ b/src/components/page/meetingDetail/Feed/Skeleton/DesktopFeedListSkeleton.tsx
@@ -29,4 +29,7 @@ const SDesktopFeedListSkeleton = styled('div', {
   gap: '24px 30px',
   margin: '0 auto',
   mt: '$56',
+  '@tablet': {
+    display: 'none',
+  },
 });


### PR DESCRIPTION
## 🚩 관련 이슈
- close #662 

## 📋 작업 내용
- [x] 피드 아이템 : 피드 작성자 프로필 사진, 피드 섬네일에 getResizedImage 적용
  <img src="https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/c43eeaaf-49ed-4952-b80e-28fed9a76890" width="300" />

- [x] 피드 상세 : 데스크탑에서 보이는 모임 섬네일에 getResizedImage 적용
  ![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/81987af2-08c4-4ece-af8a-b5dc9485c9d9)


## 📌 PR Point
- 현재 Avatar 컴포넌트는 아래와 같습니다.
  ```typescript
  export default function Avatar({ src, alt, sx, className, Overlay }: AvatarProps) {
    return (
      <SContainer style={sx} className={className}>
        {Overlay}
        {src ? <SImage src={getResizedImage(src, 32)} alt={alt} /> : <ProfileDefaultIcon />}
      </SContainer>
    );
  }
  ```
  피드 상세 페이지에서는 44 x 44 크기인데 32로 고정되어 있어서 약간 흐릿하게 보이는 것 같습니다.
  size도 전달받을 수 있도록 수정하고, 기본 값을 32로 설정하는 건 어떨까요?

  ```typescript
  interface AvatarProps {
    src?: string;
    size?: number;
    alt: string;
    sx?: CSSProperties;
    className?: string;
    Overlay?: React.ReactNode;
  }
  
  export default function Avatar({ src, size = 32, alt, sx, className, Overlay }: AvatarProps) {
    return (
      <SContainer style={sx} className={className}>
        {Overlay}
        {src ? <SImage src={getResizedImage(src, size)} alt={alt} /> : <ProfileDefaultIcon />}
      </SContainer>
    );
  }
  ```