### PR TITLE
피드 내용 최대 3줄까지 보이도록 설정

### DIFF
--- a/src/components/page/meetingDetail/Feed/FeedItem/index.tsx
+++ b/src/components/page/meetingDetail/Feed/FeedItem/index.tsx
@@ -6,7 +6,7 @@ import { ampli } from '@/ampli';
 import { UserResponse } from '@api/user';
 import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
 import Avatar from '@components/avatar/Avatar';
-import { AVATAR_MAX_LENGTH, CARD_CONTENT_MAX_LENGTH, CARD_TITLE_MAX_LENGTH } from '@constants/feed';
+import { AVATAR_MAX_LENGTH, CARD_TITLE_MAX_LENGTH } from '@constants/feed';
 import { THUMBNAIL_IMAGE_INDEX } from '@constants/index';
 import { playgroundLink } from '@sopt-makers/playground-common';
 import { fromNow } from '@utils/dayjs';
@@ -60,7 +60,7 @@ const FeedItem = ({ post, HeaderSection, LikeButton, onClick }: FeedItemProps) =
       </STop>
 
       <STitle>{truncateText(title, CARD_TITLE_MAX_LENGTH)}</STitle>
-      <SContent>{truncateText(contents, CARD_CONTENT_MAX_LENGTH)}</SContent>
+      <SContent>{contents}</SContent>
       {images && images[THUMBNAIL_IMAGE_INDEX] && (
         <SThumbnailWrapper>
           <SThumbnail src={images[THUMBNAIL_IMAGE_INDEX]} alt="" />
@@ -173,6 +173,11 @@ const SContent = styled('div', {
   fontStyle: 'B2',
   whiteSpace: 'pre-wrap',
   wordBreak: 'break-all',
+  display: '-webkit-box',
+  textOverflow: 'ellipsis',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 3,
+  overflow: 'hidden',
   '@tablet': {
     fontStyle: 'B3',
   },

--- a/src/constants/feed.ts
+++ b/src/constants/feed.ts
@@ -3,5 +3,4 @@ export const POST_MAX_COUNT = 999;
 export const AVATAR_MAX_LENGTH = 3;
 export const FORM_TITLE_MAX_LENGTH = 100;
 export const CARD_TITLE_MAX_LENGTH = 40;
-export const CARD_CONTENT_MAX_LENGTH = 70;
 export const TAKE_COUNT = 9;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #671 

## 📋 작업 내용
- [x] 피드 내용 최대 3줄까지 보이도록 설정

## 📌 PR Point
- 기존에는 70자 기준으로 잘랐는데, 3줄 기준으로 자르도록 수정했습니다.

## 📸 스크린샷
![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/eef4bb70-3544-4d09-9780-8a6f53412ec5)
