### PR TITLE
상단 텍스트와 버튼이 이미지에 가려지는 이슈 해결

### DIFF
--- a/src/components/modal/ImageCarouselModal.tsx
+++ b/src/components/modal/ImageCarouselModal.tsx
@@ -82,6 +82,7 @@ const Counter = styled('div', {
   position: 'absolute',
   top: '28px',
   left: '48px',
+  zIndex: '$1',
   color: 'white',
   fontStyle: 'T1',
   '@tablet': {
@@ -95,6 +96,7 @@ const CloseButton = styled('button', {
   position: 'absolute',
   top: '32px',
   right: '48px',
+  zIndex: '$1',
   width: '24px',
   height: '24px',
   border: 'none',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #678 

## 📋 작업 내용
- [x] z-index로 상단 텍스트와 버튼이 이미지에 가려지는 이슈 해결

## 📸 스크린샷
|as-is|to-be|
|:-:|:-:|
|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/056fd0d9-dd6e-4d00-9163-05ef7a98aabc)|![image](https://github.com/sopt-makers/sopt-crew-frontend/assets/58380158/396773eb-874e-422b-a831-b7af7999228b)|