### PR TITLE
모임 둘러보기 모바일 UI 구현

### DIFF
--- a/src/components/groupBrowsing/mobileSizeCard.stories.ts
+++ b/src/components/groupBrowsing/mobileSizeCard.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import MobileSizeCard from './mobileSizeCard';
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
+const meta: Meta<typeof MobileSizeCard> = {
+  title: 'MobileSizeCard',
+  component: MobileSizeCard,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof MobileSizeCard>;
+
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/groupBrowsing/mobileSizeCard.tsx
+++ b/src/components/groupBrowsing/mobileSizeCard.tsx
@@ -1,0 +1,103 @@
+import { styled } from 'stitches.config';
+import { getResizedImage } from '@utils/image';
+import { EApprovalStatus, RECRUITMENT_STATUS } from '@constants/option';
+import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
+
+export default function MobileSizeCard() {
+  return (
+    <div>
+      <ImageWrapper>
+        <SStatus recruitingStatus={1}>{RECRUITMENT_STATUS[1]}</SStatus>
+        <SThumbnailImage
+          css={{
+            backgroundImage: `url(${getResizedImage(
+              'https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/05/13/e907b6b8-015b-4685-854d-47f633c90c53.jpeg',
+              140
+            )})`,
+            backgroundSize: 'cover',
+          }}
+        />
+      </ImageWrapper>
+      <STitleSection>
+        <STitle>
+          {' '}
+          <SCategory isStudy={true}>행사</SCategory>
+          안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요안녕하세요
+        </STitle>
+      </STitleSection>
+    </div>
+  );
+}
+
+const ImageWrapper = styled('div', {
+  position: 'relative',
+});
+const SThumbnailImage = styled('div', {
+  width: '140px',
+  height: '96px',
+  overflow: 'hidden',
+  borderRadius: '$8',
+  backgroundColor: '$gray800',
+  backgroundSize: 'cover',
+  backgroundPosition: 'center center',
+  backgroundRepeat: 'no-repeat',
+});
+
+const SStatus = styled('div', {
+  position: 'absolute',
+  top: '8px',
+  left: '8px',
+  borderRadius: '$4',
+  padding: '$3 $5',
+  fontStyle: 'T5',
+  variants: {
+    recruitingStatus: {
+      0: {
+        backgroundColor: '$gray600',
+      },
+      1: {
+        backgroundColor: '$secondary',
+        color: '$gray950',
+      },
+      2: {
+        backgroundColor: '$gray700',
+      },
+    },
+  },
+});
+
+const STitleSection = styled('div', {
+  maxWidth: '140px',
+  fontStyle: 'T7',
+  fontAg: '14_semibold_140',
+  flexType: 'verticalCenter',
+  '@tablet': {
+    my: '$8',
+  },
+});
+const SCategory = styled('span', {
+  mr: '$3',
+  variants: {
+    isStudy: {
+      true: { color: '$secondary' },
+      false: { color: '$success' },
+    },
+  },
+});
+
+const STitle = styled('span', {
+  mt: '$12',
+  overflow: 'hidden',
+  whiteSpace: 'normal',
+  textOverflow: 'ellipsis',
+  WebkitBoxOrient: 'vertical',
+  wordBreak: 'break-all',
+  display: '-webkit-box',
+  WebkitLineClamp: 2,
+  color: '$gray10',
+  '@tablet': {
+    fontAg: '14_semibold_140',
+    maxWidth: '140px',
+    minHeight: '40px',
+  },
+});

--- a/src/components/groupBrowsing/mobileSizeCard.tsx
+++ b/src/components/groupBrowsing/mobileSizeCard.tsx
@@ -1,9 +1,8 @@
 import { styled } from 'stitches.config';
 import { getResizedImage } from '@utils/image';
-import { EApprovalStatus, RECRUITMENT_STATUS } from '@constants/option';
-import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
+import { RECRUITMENT_STATUS } from '@constants/option';
 
-export default function MobileSizeCard() {
+const MobileSizeCard = () => {
   return (
     <div>
       <ImageWrapper>
@@ -27,7 +26,9 @@ export default function MobileSizeCard() {
       </STitleSection>
     </div>
   );
-}
+};
+
+export default MobileSizeCard;
 
 const ImageWrapper = styled('div', {
   position: 'relative',

--- a/src/components/groupBrowsing/mobileSizeCard.tsx
+++ b/src/components/groupBrowsing/mobileSizeCard.tsx
@@ -49,7 +49,10 @@ const SStatus = styled('div', {
   left: '8px',
   borderRadius: '$4',
   padding: '$3 $5',
-  fontStyle: 'T5',
+  fontSize: '11px',
+  lineHeight: '14px',
+  fontWeight: '600',
+  color: '$gray800',
   variants: {
     recruitingStatus: {
       0: {
@@ -68,13 +71,13 @@ const SStatus = styled('div', {
 
 const STitleSection = styled('div', {
   maxWidth: '140px',
-  fontStyle: 'T7',
-  fontAg: '14_semibold_140',
+  fontSize: '14px',
+  fontWeight: '600',
+  lineHeight: '20px',
   flexType: 'verticalCenter',
-  '@tablet': {
-    my: '$8',
-  },
+  mt: '$12',
 });
+
 const SCategory = styled('span', {
   mr: '$3',
   variants: {
@@ -86,7 +89,6 @@ const SCategory = styled('span', {
 });
 
 const STitle = styled('span', {
-  mt: '$12',
   overflow: 'hidden',
   whiteSpace: 'normal',
   textOverflow: 'ellipsis',
@@ -95,9 +97,6 @@ const STitle = styled('span', {
   display: '-webkit-box',
   WebkitLineClamp: 2,
   color: '$gray10',
-  '@tablet': {
-    fontAg: '14_semibold_140',
-    maxWidth: '140px',
-    minHeight: '40px',
-  },
+  maxWidth: '140px',
+  minHeight: '40px',
 });

--- a/src/components/groupBrowsingSlider/groupBrowsingSlider.stories.ts
+++ b/src/components/groupBrowsingSlider/groupBrowsingSlider.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import GroupBrowsingSlider from './groupBrowsingSlider';
+
+// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction
+const meta: Meta<typeof GroupBrowsingSlider> = {
+  title: 'GroupBrowsingSlider',
+  component: GroupBrowsingSlider,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof GroupBrowsingSlider>;
+
+// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
+export const Default: Story = {
+  args: {},
+};

--- a/src/components/groupBrowsingSlider/groupBrowsingSlider.tsx
+++ b/src/components/groupBrowsingSlider/groupBrowsingSlider.tsx
@@ -1,0 +1,21 @@
+import { styled } from 'stitches.config';
+import React from 'react';
+import MobileSizeCard from '@components/groupBrowsing/mobileSizeCard';
+
+const GroupBrowsingSlider = () => {
+  return (
+    <SContainer>
+      {[0, 0, 0, 0, 0, 0, 0, 0].map((item, idx) => (
+        <MobileSizeCard key={idx} />
+      ))}{' '}
+    </SContainer>
+  );
+};
+
+export default GroupBrowsingSlider;
+
+const SContainer = styled('div', {
+  display: 'flex',
+  gap: '$12',
+  overflowX: 'auto',
+});

--- a/src/components/groupBrowsingSlider/groupBrowsingSlider.tsx
+++ b/src/components/groupBrowsingSlider/groupBrowsingSlider.tsx
@@ -4,17 +4,17 @@ import MobileSizeCard from '@components/groupBrowsing/mobileSizeCard';
 
 const GroupBrowsingSlider = () => {
   return (
-    <SContainer>
+    <SSlider>
       {[0, 0, 0, 0, 0, 0, 0, 0].map((item, idx) => (
         <MobileSizeCard key={idx} />
       ))}{' '}
-    </SContainer>
+    </SSlider>
   );
 };
 
 export default GroupBrowsingSlider;
 
-const SContainer = styled('div', {
+const SSlider = styled('div', {
   display: 'flex',
   gap: '$12',
   overflowX: 'auto',


### PR DESCRIPTION
## 🚩 관련 이슈
- close #682 

## 📋 작업 내용
- [x] 모임 둘러보기 모바일 UI 구현

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
- 어떤 위험이나 우려가 발견되었는지
- 어떤 부분에 리뷰어가 집중해야 하는지
- 개발하면서 어떤 점이 궁금했는지

정말 그냥 더미 데이터에 UI만 구현했습니다! 
모바일에선 슬라이더가 아닌 기본 가로 스크롤이라 따로 크게 구현할게 없더라구요..?!


## 📸 스크린샷
![Mar-28-2024 20-15-29](https://github.com/sopt-makers/sopt-crew-frontend/assets/87795291/05950267-b8ce-49c2-8633-5abd44f19a55)
