### PR TITLE
throttle 사용해서 버튼 중복 클릭 방지

### DIFF
--- a/src/components/feed/Modal/FeedCreateWithSelectMeetingModal.tsx
+++ b/src/components/feed/Modal/FeedCreateWithSelectMeetingModal.tsx
@@ -14,6 +14,7 @@ import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { styled } from 'stitches.config';
 import FeedFormPresentation from './FeedFormPresentation';
 import { FormCreateType, feedCreateSchema } from './feedSchema';
+import useThrottle from '@hooks/useThrottle';
 
 const DevTool = dynamic(() => import('@hookform/devtools').then(module => module.DevTool), {
   ssr: false,
@@ -61,11 +62,11 @@ function FeedCreateWithSelectMeetingModal({ isModalOpened, handleModalClose }: C
     submitModal.handleModalOpen();
   };
 
-  const onSubmit = async () => {
+  const onSubmit = useThrottle(async () => {
     const createFeedParameter = { ...formMethods.getValues() };
     await mutateCreateFeed(createFeedParameter);
     ampli.completedFeedPosting({ user_id: Number(me?.orgId), platform_type: platform, feed_upload: formatDate() });
-  };
+  }, 5000);
 
   useEffect(() => {}, [formMethods, isModalOpened]);
 

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 const THROTTLE_DEFAULT_TIME = 1 * 1000;
 
@@ -7,6 +7,12 @@ const useThrottle = <T extends () => void>(
   throttleTime: number | undefined = THROTTLE_DEFAULT_TIME
 ): (() => void) => {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+    }
+  }, []);
 
   return () => {
     if (timer.current) return;

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,21 @@
+import { useRef } from 'react';
+
+const THROTTLE_DEFAULT_TIME = 1 * 1000;
+
+const useThrottle = <T extends () => void>(
+  callback: T,
+  throttleTime: number | undefined = THROTTLE_DEFAULT_TIME
+): (() => void) => {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return () => {
+    if (timer.current) return;
+
+    callback();
+    timer.current = setTimeout(() => {
+      timer.current = null;
+    }, throttleTime);
+  };
+};
+
+export default useThrottle;

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -9,9 +9,11 @@ const useThrottle = <T extends () => void>(
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    if (timer.current) {
-      clearTimeout(timer.current);
-    }
+    return () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+    };
   }, []);
 
   return () => {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #700 

## 📋 작업 내용
- [x] useThrottle hook 작성 + 피드 작성 확인 버튼 클릭이벤트에 해당 훅 적용

## 📌 PR Point
- 현재 debounce 훅은 작성돼있는데, 디바운스는 마지막 이벤트 발생 시점에서 일정 시간 이후에 함수가 실행되는거라 debounce보다는 일정시간 동안 이벤트를 한번만 실행하는 throttle이 더 적합하다고 생각하여 해당 훅을 만들어서 적용했습니다.
- 5초라는 시간을 임의로 잡긴 했는데(5초 내에 연속으로 다른 피드를 작성할 일이 없을 것 같고 + submit의 비동기함수가 5초 이상 걸릴 것 같진 않아서) 말 그대로 제 피셜이라서... 더 좋은 의견이 있다면 남겨주심 좋을 것 같아요!

## 📸 스크린샷
