### PR TITLE
fix: 크로스 브라우징 이슈 해결을 위한 명확한 날짜 포맷 사용

### DIFF
--- a/src/components/form/Calendar/index.tsx
+++ b/src/components/form/Calendar/index.tsx
@@ -21,7 +21,7 @@ const CalendarInputForm = ({ selectedDate, setSelectedDate, error }: Props) => {
     return (
       <>
         <Calendar
-          value={selectedDate ? dayjs(selectedDate).toDate() : null}
+          value={selectedDate ? dayjs(selectedDate, 'YYYY-MM-DD').toDate() : null}
           onClickDay={date => setSelectedDate(dayjs(date).format('YYYY.MM.DD'))}
           formatDay={(locale, date) => dayjs(date).format('D')}
           formatShortWeekday={(locale, date) => ['SUN', 'MOM', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][date.getDay()]}


### PR DESCRIPTION
## 🚩 관련 이슈

- close #769 
<img width="462" alt="image" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/87795291/e57d8668-163e-45d5-9f40-2d3b953dae4b">
<img width="340" alt="image" src="https://github.com/sopt-makers/sopt-crew-frontend/assets/87795291/cccd370f-22fb-4473-b5eb-ec74363ea470">


## 📋 작업 내용
- [x] Date객체로 인한 크로스 브라우징 이슈 해결

## 📌 PR Point

- Invalid Date오류였고, 크롬이 아닌 다른 브라우저에서 이슈가 발견된 걸로 보아 크로스 브라우징 이슈일 것이라고 생각했습니다. 검색해보니 이런 글이 있더라구요. [Date 객체 사용 시 주의해야 할 점 (크로스 브라우징 이슈)](https://string.tistory.com/32) 몇가지 데이트 포맷은 크롬이 아닌 다른 브라우저에서는 제대로 작동하지 않고 Invalid Date로 판명될 수 있으니, 공통되는 포맷을 사용해야 한다는 내용의 글입니다..! 해당 글 참고해서 모든 브라우저에서 사용될 수 있게끔 toDate() 메소드를 쓸 때 포맷을 지정해주니 이슈가 해결된걸로 보여요. 하지만 qa는 한 번 더 진행해봐야 할 것 같습니다... 🥺

## 📸 스크린샷
