### PR TITLE
공동 모임장 UI 퍼블리싱

### DIFF
--- a/packages/react-mentions/src/SuggestionsOverlay.js
+++ b/packages/react-mentions/src/SuggestionsOverlay.js
@@ -78,6 +78,7 @@ function SuggestionsOverlay({
     return suggestionsToRender
   }
 
+  //여기서 엔터를 눌렀을 때 해당 값 설정되도록 만들수는 없을까?
   const renderSuggestion = (result, queryInfo, index) => {
     const isFocused = index === focusIndex
     const { childIndex, query } = queryInfo

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,6 +20,7 @@ import '@sopt-makers/ui/dist/index.css';
 import { DialogProvider, ToastProvider } from '@sopt-makers/ui';
 import { MentionProvider } from '@components/feed/Mention/MentionContext';
 import { globalStyles } from 'styles/globals';
+import { SearchMentionProvider } from '@components/form/SearchMention/SearchMentionContext';
 
 // 리액트 하이드레이션 에러를 피하기 위해 사용. 렌더링에 관여하지 않는 코드여서 if 문으로 분기처리
 if (typeof window !== 'undefined') {
@@ -97,40 +98,42 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, []);
 
   return (
-    <MentionProvider>
-      <QueryClientProvider client={queryClient}>
-        <SEO />
-        <Script
-          id="gtag-base"
-          strategy="afterInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `
+    <SearchMentionProvider>
+      <MentionProvider>
+        <QueryClientProvider client={queryClient}>
+          <SEO />
+          <Script
+            id="gtag-base"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `
             (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer', '${GTM_ID}');
           `,
-          }}
-        />
-        <Layout>
-          <DialogProvider>
-            <ToastProvider>
-              <OverlayProvider>
-                {isServiceReady ? (
-                  <>
-                    <Header />
-                    <Component {...pageProps} />
-                  </>
-                ) : (
-                  <Loader />
-                )}
-              </OverlayProvider>
-            </ToastProvider>
-          </DialogProvider>
-        </Layout>
-      </QueryClientProvider>
-    </MentionProvider>
+            }}
+          />
+          <Layout>
+            <DialogProvider>
+              <ToastProvider>
+                <OverlayProvider>
+                  {isServiceReady ? (
+                    <>
+                      <Header />
+                      <Component {...pageProps} />
+                    </>
+                  ) : (
+                    <Loader />
+                  )}
+                </OverlayProvider>
+              </ToastProvider>
+            </DialogProvider>
+          </Layout>
+        </QueryClientProvider>
+      </MentionProvider>
+    </SearchMentionProvider>
   );
 }
 

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -38,6 +38,11 @@ const EditPage = () => {
   const formMethods = useForm<FormType>({
     mode: 'onChange',
     resolver: zodResolver(schema),
+    defaultValues: {
+      detail: {
+        coLeader: [],
+      },
+    },
   });
 
   const onSubmit: SubmitHandler<FormType> = async formData => {

--- a/pages/make/index.tsx
+++ b/pages/make/index.tsx
@@ -22,6 +22,11 @@ const MakePage = () => {
   const formMethods = useForm<FormType>({
     mode: 'onChange',
     resolver: zodResolver(schema),
+    defaultValues: {
+      detail: {
+        coLeader: [],
+      },
+    },
   });
   const { isValid } = formMethods.formState;
   const { mutateAsync: mutateCreateMeeting, isLoading: isSubmitting } = useMutation({

--- a/src/components/form/FormController/index.tsx
+++ b/src/components/form/FormController/index.tsx
@@ -5,7 +5,7 @@ import { Option } from '../Select/OptionItem';
 interface FormControllerProps {
   name: string;
   render: ControllerProps['render'];
-  defaultValue?: boolean | string | number | Option | Option[];
+  defaultValue?: boolean | string | number | Option | Option[] | string[];
 }
 
 function FormController({ name, render, defaultValue }: FormControllerProps) {

--- a/src/components/form/HelpMessage/index.tsx
+++ b/src/components/form/HelpMessage/index.tsx
@@ -13,7 +13,7 @@ const HelpMessage = ({ children }: HelpMessageProps) => {
 export default HelpMessage;
 
 const SHelpMessage = styled('span', {
-  marginBottom: 18,
+  marginBottom: 8,
   display: 'inline-block',
   ...fontsObject.LABEL_4_12_SB,
   color: '$gray300',

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -1,12 +1,10 @@
 import { styled } from 'stitches.config';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { IconPlus } from '@sopt-makers/icons';
-import CommonMention from '@components/feed/Mention';
 import SearchMention from '@components/form/SearchMention';
 import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
 import { IconSearch } from '@sopt-makers/icons';
 import { IconXCircle } from '@sopt-makers/icons';
-import { SearchField } from '@sopt-makers/ui';
 import { useQueryGetMentionUsers } from '@api/user/hooks';
 import { fontsObject } from '@sopt-makers/fonts';
 import { IconXClose } from '@sopt-makers/icons';
@@ -40,15 +38,24 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
   };
 
   const [showInput, setShowInput] = useState(false);
-
   const [comment, setComment] = useState('');
+
   const [isFocused, setIsFocused] = useState(false);
   const [userId, setUserId] = useState<number | null>(null);
-
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-  const handleAddLeader = () => {
-    // 리더 추가 기능 비활성화
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth <= 414);
+    };
+    window.addEventListener('resize', handleResize);
+    handleResize(); // Initial check
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const handleBackdropClick = () => {
+    setShowInput(false);
   };
 
   const handleDeleteLeader = (index: number) => {
@@ -73,29 +80,59 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
               <StyledIconPlus />
             </AddButton>
             {showInput && (
-              <CommentInput>
-                <InputBox isActive={comment !== ''}>
-                  <SearchMention
-                    mentionUserList={mentionUserList}
-                    inputRef={inputRef}
-                    value={comment}
-                    setValue={setComment}
-                    placeholder={`멤버 검색`}
-                    setIsFocused={setIsFocused}
-                    setUserId={setUserId}
-                    onUserSelect={handleUserSelect}
-                  />
-                  {comment ? (
-                    <StyledIconXCircle
-                      onClick={() => {
-                        setComment('');
-                      }}
-                    />
-                  ) : (
-                    <StyledIconSearch />
-                  )}
-                </InputBox>
-              </CommentInput>
+              <>
+                {isMobile ? (
+                  <Backdrop onClick={handleBackdropClick}>
+                    <CommentInput onClick={e => e.stopPropagation()}>
+                      <InputBox isActive={comment !== ''}>
+                        <SearchMention
+                          mentionUserList={mentionUserList}
+                          inputRef={inputRef}
+                          value={comment}
+                          setValue={setComment}
+                          placeholder={`멤버 검색`}
+                          setIsFocused={setIsFocused}
+                          setUserId={setUserId}
+                          onUserSelect={handleUserSelect}
+                        />
+                        {comment ? (
+                          <StyledIconXCircle
+                            onClick={() => {
+                              setComment('');
+                            }}
+                          />
+                        ) : (
+                          <StyledIconSearch />
+                        )}
+                      </InputBox>
+                    </CommentInput>
+                  </Backdrop>
+                ) : (
+                  <CommentInput onClick={e => e.stopPropagation()}>
+                    <InputBox isActive={comment !== ''}>
+                      <SearchMention
+                        mentionUserList={mentionUserList}
+                        inputRef={inputRef}
+                        value={comment}
+                        setValue={setComment}
+                        placeholder={`멤버 검색`}
+                        setIsFocused={setIsFocused}
+                        setUserId={setUserId}
+                        onUserSelect={handleUserSelect}
+                      />
+                      {comment ? (
+                        <StyledIconXCircle
+                          onClick={() => {
+                            setComment('');
+                          }}
+                        />
+                      ) : (
+                        <StyledIconSearch />
+                      )}
+                    </InputBox>
+                  </CommentInput>
+                )}
+              </>
             )}
           </AddLeader>
         )}
@@ -130,6 +167,18 @@ export default CoLeader;
 
 const Container = styled('div', {
   //디자인적인 건 x (에러메세지도 담아두기 위한 Container)
+});
+
+const Backdrop = styled('div', {
+  position: 'fixed',
+  width: '100vw',
+  height: '100vh',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: 'rgba(0, 0, 0, 0.7)',
+  zIndex: 10,
 });
 
 const LeadersContainer = styled('div', {
@@ -222,6 +271,27 @@ const CommentInput = styled('div', {
   background: '$gray900',
   width: '170px',
   height: '64px',
+
+  '@mobile': {
+    position: 'fixed',
+    //부모 요소 : transform, perspective, 또는 position: fixed 등의 속성
+    //자식 요소의 fixed 위치가 의도대로 표시되지 않음 -> 따라서 top 속성을 unset으로 제거해줘야 함
+    top: 'unset',
+    bottom: '0',
+    left: '0',
+    right: '0',
+
+    width: '100%', // 좌우 16px 간격
+    height: '66px', //18 + 48
+    paddingTop: '10px',
+    paddingBottom: '8px',
+    bg: 'rgba(0, 0, 0, 0.7)',
+    border: 'none',
+    br: '0',
+
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
 });
 
 const InputBox = styled('div', {
@@ -242,6 +312,10 @@ const InputBox = styled('div', {
         border: '1px solid transparent',
       },
     },
+  },
+  '@mobile': {
+    width: '328px',
+    height: '48px',
   },
 });
 

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -363,12 +363,10 @@ const SProfile = styled('a', {
     height: '$32',
     borderRadius: '50%',
     objectFit: 'cover',
-    mr: '$16',
     background: '$gray700',
     '@tablet': {
       width: '$32',
       height: '$32',
-      mr: '$8',
     },
     '@mobile': {
       width: '$20',

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -65,6 +65,7 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
                 setShowInput(true);
                 setComment('');
               }}
+              isActive={showInput}
             >
               <IconPlus style={{ width: '22px', height: '22px', color: 'white', cursor: 'pointer' }} />
             </AddButton>
@@ -221,6 +222,13 @@ const AddButton = styled('button', {
   alignItems: 'center',
   '&:hover': {
     backgroundColor: '$gray500',
+  },
+  variants: {
+    isActive: {
+      true: {
+        backgroundColor: '$gray500',
+      },
+    },
   },
 });
 

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -26,7 +26,6 @@ interface mentionableDataType {
 }
 
 const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps) => {
-  console.log('coLeaders:', coLeaders);
   const { data: mentionUserList } = useQueryGetMentionUsers();
 
   const handleUserSelect = (user: mentionableDataType) => {

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -1,0 +1,141 @@
+import { styled } from 'stitches.config';
+import React, { useState } from 'react';
+
+interface CoLeaderFieldProps {
+  value: string[];
+  onChange: (coLeaders: string[]) => void;
+  error: string | undefined;
+}
+
+const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps) => {
+  //const [coLeaders, setCoLeaders] = useState([]);
+  const [newLeader, setNewLeader] = useState('');
+
+  const handleAddLeader = () => {
+    if (newLeader && coLeaders.length < 3) {
+      onChange([...coLeaders, newLeader]);
+      setNewLeader('');
+    }
+  };
+
+  const handleDeleteLeader = (index: number) => {
+    const updatedLeaders = coLeaders.filter((_, i) => i !== index);
+    onChange(updatedLeaders);
+  };
+
+  return (
+    <Container>
+      <LeadersContainer>
+        {coLeaders.map((leader, idx) => (
+          <Leader key={idx}>
+            <LeaderAvatar>👤</LeaderAvatar>
+            <LeaderName>{leader}</LeaderName>
+            <DeleteButton onClick={() => handleDeleteLeader(idx)}>×</DeleteButton>
+          </Leader>
+        ))}
+        {coLeaders.length < 3 && (
+          <AddLeader>
+            <AddInput
+              type="text"
+              placeholder="+ 이름 입력"
+              value={newLeader}
+              onChange={e => setNewLeader(e.target.value)}
+            />
+            <AddButton type={'button'} onClick={handleAddLeader}>
+              추가
+            </AddButton>
+          </AddLeader>
+        )}
+      </LeadersContainer>
+
+      {error && <ErrorMessage>{error}</ErrorMessage>}
+    </Container>
+  );
+};
+
+export default CoLeader;
+
+const Container = styled('div', {
+  border: '1px solid $gray700',
+  padding: '16px',
+  borderRadius: '8px',
+  backgroundColor: '$gray800',
+});
+
+const LeadersContainer = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '12px',
+});
+
+const Leader = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  backgroundColor: '$gray600',
+  borderRadius: '4px',
+  padding: '4px 8px',
+  color: '$white',
+  position: 'relative',
+});
+
+const LeaderAvatar = styled('span', {
+  fontSize: '20px',
+  marginRight: '6px',
+});
+
+const LeaderName = styled('span', {
+  fontSize: '14px',
+  color: '$white',
+});
+
+const DeleteButton = styled('button', {
+  background: 'none',
+  border: 'none',
+  color: '$red500',
+  fontSize: '14px',
+  cursor: 'pointer',
+  position: 'absolute',
+  top: '0',
+  right: '0',
+  padding: '2px 4px',
+});
+
+const AddLeader = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});
+
+const AddInput = styled('input', {
+  width: '120px',
+  padding: '4px 8px',
+  borderRadius: '4px',
+  border: '1px solid $gray700',
+  backgroundColor: '$gray900',
+  color: '$white',
+  outline: 'none',
+
+  '&::placeholder': {
+    color: '$gray500',
+  },
+});
+
+const AddButton = styled('button', {
+  type: 'button', //이거 없으면 제출 처리됨!!
+  padding: '4px 8px',
+  backgroundColor: '$green500',
+  color: '$white',
+  border: 'none',
+  borderRadius: '4px',
+  cursor: 'pointer',
+
+  '&:hover': {
+    backgroundColor: '$green400',
+  },
+});
+
+const ErrorMessage = styled('div', {
+  color: '$red500',
+  fontSize: '12px',
+  marginTop: '8px',
+});

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -70,7 +70,7 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
               }}
               isActive={showInput}
             >
-              <IconPlus style={{ width: '22px', height: '22px', color: 'white', cursor: 'pointer' }} />
+              <StyledIconPlus />
             </AddButton>
             {showInput && (
               <CommentInput>
@@ -80,20 +80,19 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
                     inputRef={inputRef}
                     value={comment}
                     setValue={setComment}
-                    placeholder={`Search...`}
+                    placeholder={`멤버 검색`}
                     setIsFocused={setIsFocused}
                     setUserId={setUserId}
                     onUserSelect={handleUserSelect}
                   />
                   {comment ? (
-                    <IconXCircle
-                      style={{ width: '24px', height: '24px' }}
+                    <StyledIconXCircle
                       onClick={() => {
                         setComment('');
                       }}
                     />
                   ) : (
-                    <IconSearch style={{ width: '24px', height: '24px' }} />
+                    <StyledIconSearch />
                   )}
                 </InputBox>
               </CommentInput>
@@ -102,21 +101,23 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
         )}
 
         {/*추가된 공동 모임장 프로필 렌더링 */}
-        {coLeaders.map((leader, idx) => (
-          <Leader key={leader.id}>
-            <SProfile>
-              {leader.profileImageUrl ? (
-                <img src={leader.profileImageUrl} alt={leader.userName} />
-              ) : (
-                <ProfileDefaultIcon />
-              )}
-            </SProfile>
-            <LeaderName>{leader.userName}</LeaderName>
-            <DeleteButton type={'button'} onClick={() => handleDeleteLeader(idx)}>
-              <IconXClose style={{ width: '16px', height: '16px', color: '#9D9DA4', strokeWidth: '1.5' }} />
-            </DeleteButton>
-          </Leader>
-        ))}
+        <LeadersWrapper>
+          {coLeaders.map((leader, idx) => (
+            <Leader key={leader.id}>
+              <SProfile>
+                {leader.profileImageUrl ? (
+                  <img src={leader.profileImageUrl} alt={leader.userName} />
+                ) : (
+                  <StyledProfileDefaultIcon />
+                )}
+              </SProfile>
+              <LeaderName>{leader.userName}</LeaderName>
+              <DeleteButton type={'button'} onClick={() => handleDeleteLeader(idx)}>
+                <StyledIconXClose />
+              </DeleteButton>
+            </Leader>
+          ))}
+        </LeadersWrapper>
       </LeadersContainer>
 
       {/*추후 사용할수도 있어 만들어 둔 에러 메세지 */}
@@ -135,6 +136,19 @@ const LeadersContainer = styled('div', {
   display: 'flex',
   alignItems: 'center',
   gap: '16px',
+  '@mobile': {
+    gap: '10px',
+  },
+});
+
+const LeadersWrapper = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '10px',
+  '@mobile': {
+    gap: '8px',
+  },
 });
 
 const Leader = styled('div', {
@@ -146,18 +160,31 @@ const Leader = styled('div', {
   justifyContent: 'center',
   alignItems: 'center',
   gap: '10px',
+
   borderRadius: '10px',
   backgroundColor: '$gray900',
   flexWrap: 'nowrap',
 
   color: '$white',
   position: 'relative',
+
+  '@mobile': {
+    width: '89px',
+    height: '30px',
+    padding: '5px 8px',
+    gap: '6px',
+    borderRadius: '6.25px',
+  },
 });
 
 const LeaderName = styled('span', {
   color: '$white',
   ...fontsObject.BODY_2_16_M,
   whiteSpace: 'nowrap',
+
+  '@mobile': {
+    ...fontsObject.LABEL_5_11_SB,
+  },
 });
 
 const DeleteButton = styled('button', {
@@ -171,6 +198,10 @@ const DeleteButton = styled('button', {
   borderRadius: '50px',
   background: '$gray700',
   cursor: 'pointer',
+  '@mobile': {
+    width: '12px',
+    height: '12px',
+  },
 });
 
 const AddLeader = styled('div', {
@@ -182,7 +213,7 @@ const AddLeader = styled('div', {
 
 const CommentInput = styled('div', {
   position: 'absolute',
-  top: '40px',
+  top: '44px', //32 + 12
   display: 'inline-flex',
   padding: '8px',
   alignItems: 'flex-start',
@@ -235,6 +266,12 @@ const AddButton = styled('button', {
       },
     },
   },
+  '@mobile': {
+    width: '24px',
+    height: '24px',
+    padding: '3.75px',
+    br: '75px',
+  },
 });
 
 const ErrorMessage = styled('div', {
@@ -259,5 +296,53 @@ const SProfile = styled('a', {
       height: '$32',
       mr: '$8',
     },
+    '@mobile': {
+      width: '$20',
+      height: '$20',
+    },
+  },
+});
+
+const StyledIconXCircle = styled(IconXCircle, {
+  width: '24px',
+  height: '24px',
+  cursor: 'pointer',
+  '@mobile': {},
+});
+
+const StyledIconSearch = styled(IconSearch, {
+  width: '24px',
+  height: '24px',
+  //모바일에선 input에 다른 뷰 필요 (현재는 구현 x)
+});
+
+const StyledIconPlus = styled(IconPlus, {
+  width: '22px',
+  height: '22px',
+  color: 'white',
+  cursor: 'pointer',
+  '@mobile': {
+    width: '16.5px',
+    height: '16.5px',
+  },
+});
+
+const StyledIconXClose = styled(IconXClose, {
+  width: '12px',
+  height: '12px',
+  '@mobile': {
+    width: '8px',
+    height: '8px',
+  },
+  color: '#9D9DA4',
+  strokeWidth: '1.5',
+});
+
+const StyledProfileDefaultIcon = styled(ProfileDefaultIcon, {
+  width: '32px',
+  height: '32px',
+  '@mobile': {
+    width: '20px',
+    height: '20px',
   },
 });

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -30,7 +30,9 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
           <Leader key={idx}>
             <LeaderAvatar>👤</LeaderAvatar>
             <LeaderName>{leader}</LeaderName>
-            <DeleteButton onClick={() => handleDeleteLeader(idx)}>×</DeleteButton>
+            <DeleteButton type={'button'} onClick={() => handleDeleteLeader(idx)}>
+              ×
+            </DeleteButton>
           </Leader>
         ))}
         {coLeaders.length < 3 && (

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -57,22 +57,6 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
   return (
     <Container>
       <LeadersContainer>
-        {coLeaders.map((leader, idx) => (
-          <Leader key={leader.id}>
-            <SProfile>
-              {leader.profileImageUrl ? (
-                <img src={leader.profileImageUrl} alt={leader.userName} />
-              ) : (
-                <ProfileDefaultIcon />
-              )}
-              <span>{leader.userName}</span>
-            </SProfile>
-
-            <DeleteButton type={'button'} onClick={() => handleDeleteLeader(idx)}>
-              ×
-            </DeleteButton>
-          </Leader>
-        ))}
         {coLeaders.length < 3 && (
           <AddLeader>
             <AddButton
@@ -112,6 +96,23 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
             )}
           </AddLeader>
         )}
+
+        {coLeaders.map((leader, idx) => (
+          <Leader key={leader.id}>
+            <SProfile>
+              {leader.profileImageUrl ? (
+                <img src={leader.profileImageUrl} alt={leader.userName} />
+              ) : (
+                <ProfileDefaultIcon />
+              )}
+              <span>{leader.userName}</span>
+            </SProfile>
+
+            <DeleteButton type={'button'} onClick={() => handleDeleteLeader(idx)}>
+              ×
+            </DeleteButton>
+          </Leader>
+        ))}
       </LeadersContainer>
 
       {error && <ErrorMessage>{error}</ErrorMessage>}

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -8,6 +8,8 @@ import { IconSearch } from '@sopt-makers/icons';
 import { IconXCircle } from '@sopt-makers/icons';
 import { SearchField } from '@sopt-makers/ui';
 import { useQueryGetMentionUsers } from '@api/user/hooks';
+import { fontsObject } from '@sopt-makers/fonts';
+import { IconXClose } from '@sopt-makers/icons';
 
 interface CoLeaderFieldProps {
   value: mentionableDataType[];
@@ -57,6 +59,7 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
   return (
     <Container>
       <LeadersContainer>
+        {/*추가 버튼과 멘션 인풋 */}
         {coLeaders.length < 3 && (
           <AddLeader>
             <AddButton
@@ -98,6 +101,7 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
           </AddLeader>
         )}
 
+        {/*추가된 공동 모임장 프로필 렌더링 */}
         {coLeaders.map((leader, idx) => (
           <Leader key={leader.id}>
             <SProfile>
@@ -106,16 +110,16 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
               ) : (
                 <ProfileDefaultIcon />
               )}
-              <span>{leader.userName}</span>
             </SProfile>
-
+            <LeaderName>{leader.userName}</LeaderName>
             <DeleteButton type={'button'} onClick={() => handleDeleteLeader(idx)}>
-              ×
+              <IconXClose style={{ width: '16px', height: '16px', color: '#9D9DA4', strokeWidth: '1.5' }} />
             </DeleteButton>
           </Leader>
         ))}
       </LeadersContainer>
 
+      {/*추후 사용할수도 있어 만들어 둔 에러 메세지 */}
       {error && <ErrorMessage>{error}</ErrorMessage>}
     </Container>
   );
@@ -124,48 +128,49 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
 export default CoLeader;
 
 const Container = styled('div', {
-  border: '1px solid $gray700',
-  padding: '16px',
-  borderRadius: '8px',
-  backgroundColor: '$gray800',
+  //디자인적인 건 x (에러메세지도 담아두기 위한 Container)
 });
 
 const LeadersContainer = styled('div', {
   display: 'flex',
   alignItems: 'center',
-  gap: '12px',
+  gap: '16px',
 });
 
 const Leader = styled('div', {
+  width: '134px',
+  heigth: '48px',
+
   display: 'flex',
+  padding: '8px 12px',
+  justifyContent: 'center',
   alignItems: 'center',
-  backgroundColor: '$gray600',
-  borderRadius: '4px',
-  padding: '4px 8px',
+  gap: '10px',
+  borderRadius: '10px',
+  backgroundColor: '$gray900',
+  flexWrap: 'nowrap',
+
   color: '$white',
   position: 'relative',
 });
 
-const LeaderAvatar = styled('span', {
-  fontSize: '20px',
-  marginRight: '6px',
-});
-
 const LeaderName = styled('span', {
-  fontSize: '14px',
   color: '$white',
+  ...fontsObject.BODY_2_16_M,
+  whiteSpace: 'nowrap',
 });
 
 const DeleteButton = styled('button', {
-  background: 'none',
-  border: 'none',
-  color: '$red500',
-  fontSize: '14px',
+  display: 'flex',
+  width: '16px',
+  height: '16px',
+  padding: '2px',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  borderRadius: '50px',
+  background: '$gray700',
   cursor: 'pointer',
-  position: 'absolute',
-  top: '0',
-  right: '0',
-  padding: '2px 4px',
 });
 
 const AddLeader = styled('div', {
@@ -243,8 +248,8 @@ const SProfile = styled('a', {
   color: '$gray10',
   width: 'fit-content',
   img: {
-    width: '$60',
-    height: '$60',
+    width: '$32',
+    height: '$32',
     borderRadius: '50%',
     objectFit: 'cover',
     mr: '$16',

--- a/src/components/form/Presentation/index.tsx
+++ b/src/components/form/Presentation/index.tsx
@@ -26,6 +26,7 @@ import { useDialog } from '@sopt-makers/ui';
 import sopt_schedule_tooltip from 'public/assets/images/sopt_schedule_tooltip.png';
 import BubblePointIcon from 'public/assets/svg/bubble_point.svg';
 import JoinablePartsField from '@components/form/Presentation/JoinablePartsField';
+import CoLeader from './CoLeader';
 
 interface PresentationProps {
   submitButtonLabel: React.ReactNode;
@@ -484,10 +485,25 @@ function Presentation({
           </div>
           {/* 모집 정보 끝 */}
 
-          {/* 추가 정보 - 모임장 소개 */}
+          {/* 추가 정보 - 공동 모임장 */}
           <div>
             <SFormSectionDevider>4. 추가 정보</SFormSectionDevider>
             <SectionLine />
+            <Label size="small">공동 모임장</Label>
+            <HelpMessage>
+              공동 모임장은 총 3명까지 등록 가능해요. 플레이그라운드에서의 모임 관리/편집은 모임 개설자만 가능해요.
+            </HelpMessage>
+
+            <FormController
+              name="detail.coLeader"
+              render={({ field: { value, onChange }, fieldState: { error } }) => {
+                return <CoLeader value={value} onChange={onChange} error={error?.message} />;
+              }}
+            ></FormController>
+          </div>
+
+          {/* 추가 정보 - 모임장 소개 */}
+          <div>
             <Label size="small">모임장 소개</Label>
 
             <SNeedMentorFieldWrapper>

--- a/src/components/form/SearchMention/SearchMentionContext.tsx
+++ b/src/components/form/SearchMention/SearchMentionContext.tsx
@@ -14,6 +14,11 @@ interface SearchMentionContextProps {
   setUser: Dispatch<SetStateAction<User>>;
 }
 
+/*
+  참고) SearchMentionContext는 공동모임장을 위한 context입니다. 
+  혹시 나중에 사용할 일이 생길 수도 있을까봐 간단하게 구조만 작성해두었습니다.
+*/
+
 const SearchMentionContext = createContext<SearchMentionContextProps>({
   user: { userName: '', userId: 0 },
   setUser: () => {},

--- a/src/components/form/SearchMention/SearchMentionContext.tsx
+++ b/src/components/form/SearchMention/SearchMentionContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useState, Dispatch, SetStateAction } from 'react';
+
+interface SearchMentionProviderProps {
+  children: React.ReactNode;
+}
+
+interface User {
+  userName: string;
+  userId: number;
+}
+
+interface SearchMentionContextProps {
+  user: User;
+  setUser: Dispatch<SetStateAction<User>>;
+}
+
+const SearchMentionContext = createContext<SearchMentionContextProps>({
+  user: { userName: '', userId: 0 },
+  setUser: () => {},
+});
+
+const SearchMentionProvider: React.FC<SearchMentionProviderProps> = ({ children }) => {
+  const [user, setUser] = useState({ userName: '', userId: 0 });
+
+  return <SearchMentionContext.Provider value={{ user, setUser }}>{children}</SearchMentionContext.Provider>;
+};
+
+export { SearchMentionContext, SearchMentionProvider };

--- a/src/components/form/SearchMention/index.tsx
+++ b/src/components/form/SearchMention/index.tsx
@@ -260,6 +260,11 @@ const fadeIn = keyframes({
   '100%': { opacity: 1, transform: 'translateY(10px)' },
 });
 
+const fadeInUp = keyframes({
+  '0%': { opacity: 0, transform: 'translateY(0px)' }, // 위로 올라가는 애니메이션
+  '100%': { opacity: 1, transform: 'translateY(-10px)' },
+});
+
 const SCustomSuggestionsContainer = styled('div', {
   borderRadius: '13px',
   boxSizing: 'border-box',
@@ -291,7 +296,7 @@ const SCustomSuggestionsContainer = styled('div', {
   },
 
   '@tablet': {
-    position: 'fixed',
+    position: 'absolute',
     left: '0',
     bottom: '120px',
     width: '100%',
@@ -299,6 +304,20 @@ const SCustomSuggestionsContainer = styled('div', {
     height: '100%',
     border: 'none',
     borderRadius: '20px',
+  },
+
+  //@mobile alias 사용 불가 (react-mention 에서 렌더링하기 때문)
+  '@media (max-width: 414px)': {
+    position: 'fixed',
+    top: 'unset', //부모 요소 - transform, perspective, fixed 일 경우 필요
+    bottom: '66px', //8 + 48 + 10
+    left: '0',
+    right: '0',
+    width: '328px',
+    maxHeight: '210px',
+    margin: '0 auto',
+
+    animation: `${fadeInUp} 0.5s forwards`,
   },
 });
 

--- a/src/components/form/SearchMention/index.tsx
+++ b/src/components/form/SearchMention/index.tsx
@@ -1,0 +1,322 @@
+import { useQueryGetMentionUsers } from '@api/user/hooks';
+import { parseMentionedUserIds } from '@components/util/parseMentionedUserIds';
+import { colors } from '@sopt-makers/colors';
+import { fontsObject } from '@sopt-makers/fonts';
+import { keyframes, styled } from '@stitches/react';
+import DefaultProfile from 'public/assets/svg/mention_profile_default.svg';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
+import { Mention, MentionsInput, SuggestionDataItem } from 'react-mentions';
+import { SearchMentionContext } from './SearchMentionContext';
+
+interface mentionableDataType {
+  id: number;
+  display: string;
+  orgId: number;
+  userName: string;
+  recentPart: string;
+  recentGeneration: number;
+  profileImageUrl: string;
+}
+
+interface SearchMentionProps {
+  mentionUserList: mentionableDataType[];
+  inputRef: React.RefObject<HTMLTextAreaElement>;
+  value: string;
+  setValue: (val: string) => void;
+  placeholder?: string;
+  setIsFocused: React.Dispatch<React.SetStateAction<boolean>>;
+  setUserId: React.Dispatch<React.SetStateAction<number | null>>;
+  onClick?: () => void;
+  onUserSelect: (user: mentionableDataType) => void;
+}
+
+const SearchMention = ({
+  mentionUserList,
+  inputRef,
+  value,
+  setValue,
+  placeholder,
+  setIsFocused,
+  setUserId,
+  onClick,
+  onUserSelect,
+}: SearchMentionProps) => {
+  useEffect(() => {
+    console.log(value);
+  }, [value]);
+  //전역 상태(이걸로 user에게 필요한 정보 잘 모아서, api 요청 보내야할 듯) -> 근데 지금은 딱히 사용하고 있지 않음
+  const { user, setUser } = useContext(SearchMentionContext);
+  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1); // -1은 선택된 것이 없음을 나타냄
+
+  const handleUserClick = (user: mentionableDataType) => {
+    onUserSelect(user);
+    setValue('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      const suggestions = getFilteredAndRandomUsers(
+        value,
+        mentionUserList.map(v => ({ ...v, id: v.orgId, display: v.userName }))
+      );
+
+      if (suggestions.length > 0) {
+        // If there are suggestions, select the first one
+        handleUserClick(suggestions[0]);
+        e.preventDefault(); // Prevent default behavior of Enter key (like submitting a form)
+      }
+    }
+  };
+
+  const filterUsersBySearchTerm = (searchTerm: string, users: mentionableDataType[]) => {
+    return users?.filter((v: mentionableDataType) => v.userName.includes(searchTerm));
+  };
+
+  const getRandomUsers = (users: mentionableDataType[]) => {
+    const shuffled = users?.sort(() => 0.5 - Math.random());
+    return shuffled.slice(0, 30);
+  };
+
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const userAgent = navigator.userAgent;
+    if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(userAgent)) {
+      setIsMobile(true);
+    }
+  }, []);
+
+  const getFilteredAndRandomUsers = (searchTerm: string, users: mentionableDataType[]) => {
+    const filteredUsers = filterUsersBySearchTerm(searchTerm, users);
+    const randomUsers = getRandomUsers(filteredUsers);
+    return randomUsers;
+  };
+
+  const customSuggestionsContainer = (children: React.ReactNode) => {
+    return <SCustomSuggestionsContainer>{children}</SCustomSuggestionsContainer>;
+  };
+
+  //이게 인물 하나 하나의 모습
+  const renderSuggestion = useCallback((suggestion: SuggestionDataItem) => {
+    return (
+      <>
+        <SRenderSuggestion
+          key={suggestion.id}
+          onClick={() => handleUserClick(suggestion as mentionableDataType)}
+          onKeyDown={(e: React.KeyboardEvent) => {
+            //엔터 누르면 간편히 설정되도록 하고 싶은데, 위에 li(aria-selected 속성 사용)를 사용해야할 것 같아서..
+            //아직은 구현 못함
+            if (e.key === 'Enter') {
+              handleUserClick(suggestion as mentionableDataType);
+            }
+          }}
+        >
+          {(suggestion as mentionableDataType).profileImageUrl ? (
+            <SImageWrapper>
+              <img src={(suggestion as mentionableDataType).profileImageUrl} alt="Img" />
+            </SImageWrapper>
+          ) : (
+            <DefaultProfile />
+          )}
+
+          <div>
+            <div>{suggestion.display}</div>
+            <p>
+              {(suggestion as mentionableDataType).recentGeneration}기{` `}
+              {(suggestion as mentionableDataType).recentPart}
+            </p>
+          </div>
+        </SRenderSuggestion>
+      </>
+    );
+  }, []);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [inputRef]);
+
+  return (
+    <MentionsInput
+      inputRef={inputRef}
+      value={value}
+      onChange={(e, newValue) => {
+        setUserId(user.userId); //아마 api 요청 보낼 때 전역상태인 user.userId를 잘 활용해야 할 거임! -> 아닌가..?
+        if (!inputRef.current) {
+          setValue(newValue);
+          return;
+        }
+        if (e.target.value.length === 0) {
+          inputRef.current.style.height = 'auto';
+        } else {
+          inputRef.current.style.height = `${inputRef.current.scrollHeight}px`;
+        }
+        setValue(newValue);
+      }}
+      placeholder={placeholder}
+      onFocus={() => setIsFocused(true)}
+      customSuggestionsContainer={customSuggestionsContainer}
+      style={FeedModalMentionStyle}
+      forceSuggestionsAboveCursor={isMobile}
+      onClick={onClick}
+      onKeyDown={(e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+          // 엔터 키를 눌렀을 때 기본 동작 방지
+          e.preventDefault();
+        }
+      }}
+    >
+      <Mention
+        trigger=""
+        displayTransform={(_, display) => display}
+        data={search => {
+          if (search.length < 1) return [];
+          const data = getFilteredAndRandomUsers(
+            search,
+            mentionUserList?.map((v: mentionableDataType) => ({ ...v, id: v.orgId, display: v.userName }))
+          );
+          return data;
+        }}
+        renderSuggestion={renderSuggestion}
+      />
+    </MentionsInput>
+  );
+};
+
+export default SearchMention;
+
+const SImageWrapper = styled('div', {
+  img: {
+    objectFit: 'cover',
+    width: '32px',
+    height: '32px',
+    borderRadius: '100%',
+  },
+});
+
+const FeedModalMentionStyle = {
+  width: '100%',
+  height: '100%',
+  '&multiLine': {
+    control: {
+      fontWeight: 'normal',
+      fontFamily: 'inherit',
+      fontSize: 'inherit',
+      lineHeight: 'inherit',
+      width: '100%',
+      height: '100%',
+      boxSizing: 'border-box',
+    },
+    input: {
+      color: colors.gray50,
+      innerHeight: '0',
+      borderRadius: '10px',
+      border: 'none',
+      padding: '0',
+      margin: '0',
+      marginTop: '0',
+      marginLeft: '0',
+      boxSizing: 'border-box',
+      overflow: 'auto',
+      width: '100%',
+      maxHeight: '208px',
+      overscrollBehavior: 'none',
+      fontFamily: 'inherit',
+      fontWeight: 'normal',
+      fontSize: 'inherit',
+      lineHeight: 'inherit',
+    },
+    highlighter: {
+      color: colors.success,
+      innerHeight: '0',
+      border: 'none',
+      padding: '0',
+      margin: '0',
+      marginTop: '0',
+      marginLeft: '0',
+      overflow: 'auto',
+      boxSizing: 'border-box',
+      maxHeight: '208px',
+      pointerEvents: 'none',
+      width: '100%',
+      zIndex: '1',
+    },
+  },
+  suggestions: {
+    backgroundColor: 'transparent',
+    item: {
+      minWidth: '154px',
+      borderRadius: '8px',
+      '&focused': {
+        background: colors.gray800,
+      },
+    },
+  },
+};
+
+const fadeIn = keyframes({
+  '0%': { opacity: 0, transform: 'translateY(0)' },
+  '100%': { opacity: 1, transform: 'translateY(10px)' },
+});
+
+const SCustomSuggestionsContainer = styled('div', {
+  borderRadius: '13px',
+  boxSizing: 'border-box',
+  width: '170px',
+  padding: '8px',
+  background: '#17181c',
+  position: 'absolute',
+  top: '18px',
+  left: '-24px',
+  border: `1px solid ${colors.gray700}`,
+
+  animation: `${fadeIn} 0.5s forwards`,
+
+  maxHeight: '230px',
+
+  overflowY: 'scroll',
+  overflowX: 'hidden',
+
+  // 스크롤 스타일
+  '&::-webkit-scrollbar': {
+    width: '4px',
+  },
+  '&::-webkit-scrollbar-thumb': {
+    backgroundColor: colors.gray600,
+    borderRadius: '10px',
+  },
+  '&::-webkit-scrollbar-track': {
+    backgroundColor: 'transparent',
+  },
+
+  '@tablet': {
+    position: 'fixed',
+    left: '0',
+    bottom: '120px',
+    width: '100%',
+    maxHeight: '418px',
+    height: '100%',
+    border: 'none',
+    borderRadius: '20px',
+  },
+});
+
+const SRenderSuggestion = styled('button', {
+  boxSizing: 'border-box',
+  padding: '8px 12px',
+  gap: '12px',
+  display: 'flex',
+  alignItems: 'center',
+  borderRadius: '8px',
+  marginBottom: '6px',
+  ...fontsObject.BODY_2_16_M,
+  color: colors.gray10,
+  '& > div > p': {
+    ...fontsObject.BODY_4_13_R,
+    color: colors.gray100,
+  },
+  '@tablet': {
+    padding: '16px 12px',
+  },
+});

--- a/src/components/form/SearchMention/index.tsx
+++ b/src/components/form/SearchMention/index.tsx
@@ -1,5 +1,3 @@
-import { useQueryGetMentionUsers } from '@api/user/hooks';
-import { parseMentionedUserIds } from '@components/util/parseMentionedUserIds';
 import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
 import { keyframes, styled } from '@stitches/react';
@@ -41,18 +39,16 @@ const SearchMention = ({
   onClick,
   onUserSelect,
 }: SearchMentionProps) => {
-  useEffect(() => {
-    console.log(value);
-  }, [value]);
-  //전역 상태(이걸로 user에게 필요한 정보 잘 모아서, api 요청 보내야할 듯) -> 근데 지금은 딱히 사용하고 있지 않음
+  //전역 상태 - 혹시 필요하면 context 적절히 조작하여 사용
   const { user, setUser } = useContext(SearchMentionContext);
-  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1); // -1은 선택된 것이 없음을 나타냄
+  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(-1);
 
   const handleUserClick = (user: mentionableDataType) => {
     onUserSelect(user);
     setValue('');
   };
 
+  //엔터만 눌러도 추가가 되도록 함수 구현 -> 지금은 사용하고 있지 않음.
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       const suggestions = getFilteredAndRandomUsers(
@@ -61,9 +57,9 @@ const SearchMention = ({
       );
 
       if (suggestions.length > 0) {
-        // If there are suggestions, select the first one
+        // select the first suggestion
         handleUserClick(suggestions[0]);
-        e.preventDefault(); // Prevent default behavior of Enter key (like submitting a form)
+        e.preventDefault();
       }
     }
   };
@@ -96,7 +92,7 @@ const SearchMention = ({
     return <SCustomSuggestionsContainer>{children}</SCustomSuggestionsContainer>;
   };
 
-  //이게 인물 하나 하나의 모습
+  //인물 하나 하나의 모습
   const renderSuggestion = useCallback((suggestion: SuggestionDataItem) => {
     return (
       <>
@@ -104,8 +100,8 @@ const SearchMention = ({
           key={suggestion.id}
           onClick={() => handleUserClick(suggestion as mentionableDataType)}
           onKeyDown={(e: React.KeyboardEvent) => {
-            //엔터 누르면 간편히 설정되도록 하고 싶은데, 위에 li(aria-selected 속성 사용)를 사용해야할 것 같아서..
-            //아직은 구현 못함
+            //엔터 누르면 간편히 설정되도록 하고 싶은데,
+            //위에 react-mention의 li(aria-selected 속성 사용)를 조작해야할 것 같아서.. 아직은 구현 못함
             if (e.key === 'Enter') {
               handleUserClick(suggestion as mentionableDataType);
             }
@@ -142,7 +138,7 @@ const SearchMention = ({
       inputRef={inputRef}
       value={value}
       onChange={(e, newValue) => {
-        setUserId(user.userId); //아마 api 요청 보낼 때 전역상태인 user.userId를 잘 활용해야 할 거임! -> 아닌가..?
+        setUserId(user.userId); //필요한 경우가 있을까봐 설정해둠
         if (!inputRef.current) {
           setValue(newValue);
           return;
@@ -162,7 +158,7 @@ const SearchMention = ({
       onClick={onClick}
       onKeyDown={(e: React.KeyboardEvent) => {
         if (e.key === 'Enter') {
-          // 엔터 키를 눌렀을 때 기본 동작 방지
+          // 엔터 키를 눌렀을 때 기본 동작(개행) 방지
           e.preventDefault();
         }
       }}
@@ -260,8 +256,9 @@ const fadeIn = keyframes({
   '100%': { opacity: 1, transform: 'translateY(10px)' },
 });
 
+// 위로 올라가는 애니메이션
 const fadeInUp = keyframes({
-  '0%': { opacity: 0, transform: 'translateY(0px)' }, // 위로 올라가는 애니메이션
+  '0%': { opacity: 0, transform: 'translateY(0px)' },
   '100%': { opacity: 1, transform: 'translateY(-10px)' },
 });
 

--- a/src/components/form/TableOfContents/index.tsx
+++ b/src/components/form/TableOfContents/index.tsx
@@ -18,9 +18,9 @@ function TableOfContents({ label }: TableOfContentsProps) {
   const isCategoryValid = form.category?.value && !errors.category;
   // console.log('카테고리', '' + form.category?.value, isCategoryValid);
   const isImageValid = form.files && form.files.length > 0;
-  console.log('이미지', isImageValid);
+  //console.log('이미지', isImageValid);
   const isDescriptionValid = form.detail && form.detail.desc && !errors.detail;
-  console.log('모임소개', isImageValid);
+  //console.log('모임소개', isImageValid);
   const isApplicationDateValid = form.startDate && form.endDate && !errors.startDate && !errors.endDate;
   const isTargetValid =
     form.detail &&

--- a/src/components/page/meetingDetail/MeetingController/index.tsx
+++ b/src/components/page/meetingDetail/MeetingController/index.tsx
@@ -24,6 +24,7 @@ import { ampli } from '@/ampli';
 import ButtonLoader from '@components/loader/ButtonLoader';
 import { useDialog } from '@sopt-makers/ui';
 import { ReactNode } from 'react';
+import { fontsObject } from '@sopt-makers/fonts';
 
 interface DetailHeaderProps {
   detailData: GetMeetingResponse;
@@ -248,7 +249,7 @@ const MeetingController = ({
             >
               {hostProfileImage ? <img src={getResizedImage(hostProfileImage, 120)} /> : <ProfileDefaultIcon />}
               <span>{hostName}</span>
-              <ArrowSmallRightIcon />
+              {/* <ArrowSmallRightIcon />*/}
             </SProfileAnchor>
             {isMentorNeeded && <MentorTooltip />}
           </SHostWrapper>
@@ -408,42 +409,64 @@ const SProfileAnchor = styled('a', {
   flexType: 'verticalCenter',
   color: '$gray10',
   width: 'fit-content',
+  bg: '$gray900',
+  br: '10px',
+
+  display: 'flex',
+  padding: '12px 16px',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '14px',
+  '@mobile': {
+    padding: '5px 8px',
+    gap: '6px',
+    br: '6.25px',
+  },
 
   img: {
-    width: '$60',
-    height: '$60',
+    width: '$48',
+    height: '$48',
     borderRadius: '50%',
     objectFit: 'cover',
-    mr: '$16',
+
     background: '$gray700',
     '@tablet': {
       width: '$32',
       height: '$32',
-      mr: '$8',
+    },
+    '@mobile': {
+      width: '$20',
+      height: '$20',
     },
   },
 
   '& > svg:first-child': {
-    width: '$60',
-    height: '$60',
-    mr: '$16',
+    width: '$48',
+    height: '$48',
 
     '@tablet': {
       width: '$32',
       height: '$32',
-      mr: '$8',
+    },
+    '@mobile': {
+      width: '$20',
+      height: '$20',
     },
   },
 
   '& > span': {
-    mr: '$16',
+    ...fontsObject.TITLE_3_24_SB,
+    fontWeight: 500,
 
     '@tablet': {
       fontStyle: 'T5',
-      mr: '$2',
+    },
+    '@mobile': {
+      ...fontsObject.LABEL_5_11_SB,
     },
   },
 
+  // '>' 아이콘이 사라지면서 지금은 사용 안함.
   '& > svg:last-child > path': {
     stroke: `$gray200`,
   },

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -77,6 +77,7 @@ export const schema = z.object({
       )
       .min(1, { message: '대상 파트를 선택해주세요.' }),
     note: z.string().max(1000, { message: '1000자 까지 입력 가능합니다.' }).optional().nullable(),
+    coLeader: z.array(z.string()).optional(),
   }),
 });
 

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -77,7 +77,7 @@ export const schema = z.object({
       )
       .min(1, { message: '대상 파트를 선택해주세요.' }),
     note: z.string().max(1000, { message: '1000자 까지 입력 가능합니다.' }).optional().nullable(),
-    coLeader: z.array(z.string()).optional(),
+    coLeader: z.array(z.any()).optional(),
   }),
 });
 


### PR DESCRIPTION
## 🚩 관련 이슈

- close #936 

## 📋 작업 내용
공동 모임장 퍼블리싱 작업
- [x] 모임개설 - 공동모임장 추가 기능 구현 (react-mention 사용)
- [x] 모임 수정 - 모임 개설과 동일하게 적용
- [x] 공동모임장 멘션을 위한 SearchMention 구현 ( + Context 도 만들어두긴 했습니다. 직접적인 사용은 x)
- [x] 반응형 구현 (pc, 모바일)
- [x] 모바일 멘션 바텀시트 구현 (바깥쪽 deemed처리 된 부분 클릭 시 자동 닫기 기능도 구현)
- [x] 모임 상세보기 - 공동모임장 프로필 뷰 변경

## 📌 PR Point

- 이해를 돕고자 주석 추가해놓았으니 참고 부탁드립니다.
- 다만 pc에서 모임 개설, 수정에서 공동 모임장 추가의 경우 유저리스트가 뜰 때 약간 모습이 다릅니다.
(react-mention을 사용하기 때문에, 제가 직접 만든 input 틀에 넣어 변경하는 것은 구현이 어려웠습니다.)
- 또한 피그마와 달리 MDS에서의 기본 프로필 모양이 조금 다릅니다. 
- coLeaders.map is not a function 문제가 계속 일어나서, defaultValue를 설정해주었습니다. 
  (Presentation의 전체적인 형식(FormController를 사용하는 형식) 을 따르기 위해서)

## 📸 스크린샷

https://github.com/user-attachments/assets/b2e94f54-da61-44b8-9111-c5fce0752b98


https://github.com/user-attachments/assets/d78ecc69-d428-4df5-b617-35ff49cf18ae


https://github.com/user-attachments/assets/0cb3731f-e9aa-402d-8c97-cde9d1183915


