### PR TITLE
개설자 본인은 공동 모임장 검색이 되지 않도록 구현

### DIFF
--- a/pages/list/index.tsx
+++ b/pages/list/index.tsx
@@ -154,4 +154,5 @@ const SNoticeWrapper = styled('div', {
   '@tablet': {
     mt: '$28',
   },
+  
 });

--- a/pages/list/index.tsx
+++ b/pages/list/index.tsx
@@ -154,5 +154,4 @@ const SNoticeWrapper = styled('div', {
   '@tablet': {
     mt: '$28',
   },
-  
 });

--- a/src/api/API_LEGACY/meeting/index.ts
+++ b/src/api/API_LEGACY/meeting/index.ts
@@ -258,7 +258,6 @@ export const createMeeting = async (formData: FormType) => {
 
 export const updateMeeting = async (meetingId: string, formData: FormType) => {
   const response = await api.put(`/meeting/v2/${meetingId}`, serializeFormData(formData));
-
   return response;
 };
 

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -8,6 +8,7 @@ import { IconXCircle } from '@sopt-makers/icons';
 import { useQueryGetMentionUsers } from '@api/user/hooks';
 import { fontsObject } from '@sopt-makers/fonts';
 import { IconXClose } from '@sopt-makers/icons';
+import { useQueryMyProfile } from '@api/API_LEGACY/user/hooks';
 
 interface CoLeaderFieldProps {
   value: mentionableDataType[];
@@ -28,7 +29,10 @@ interface mentionableDataType {
 }
 
 const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps) => {
+  const { data: user } = useQueryMyProfile();
   const { data: mentionUserList } = useQueryGetMentionUsers();
+  //API 연결에서 타입을 지정해두지 않았기 때문에 any 이용
+  const filteredMeList = mentionUserList?.filter((mentionUser: any) => mentionUser.userId !== user?.id);
 
   const handleUserSelect = (user: mentionableDataType) => {
     if (coLeaders.length < 3 && !coLeaders.some(leader => leader.id === user.id)) {
@@ -87,7 +91,7 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
                     <CommentInput onClick={e => e.stopPropagation()}>
                       <InputBox isActive={comment !== ''}>
                         <SearchMention
-                          mentionUserList={mentionUserList}
+                          mentionUserList={filteredMeList}
                           inputRef={inputRef}
                           value={comment}
                           setValue={setComment}
@@ -112,7 +116,7 @@ const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps
                   <CommentInput onClick={e => e.stopPropagation()}>
                     <InputBox isActive={comment !== ''}>
                       <SearchMention
-                        mentionUserList={mentionUserList}
+                        mentionUserList={filteredMeList}
                         inputRef={inputRef}
                         value={comment}
                         setValue={setComment}

--- a/src/components/form/Presentation/CoLeader/index.tsx
+++ b/src/components/form/Presentation/CoLeader/index.tsx
@@ -28,11 +28,20 @@ interface mentionableDataType {
   userprofileImage?: string;
 }
 
+interface metionUserType {
+  userId: number;
+  orgId: number;
+  userName: string;
+  recentPart: string;
+  recentGeneration: number;
+  profileImageUrl: string;
+}
+
 const CoLeader = ({ value: coLeaders = [], onChange, error }: CoLeaderFieldProps) => {
   const { data: user } = useQueryMyProfile();
   const { data: mentionUserList } = useQueryGetMentionUsers();
   //API 연결에서 타입을 지정해두지 않았기 때문에 any 이용
-  const filteredMeList = mentionUserList?.filter((mentionUser: any) => mentionUser.userId !== user?.id);
+  const filteredMeList = mentionUserList?.filter((mentionUser: metionUserType) => mentionUser.userId !== user?.id);
 
   const handleUserSelect = (user: mentionableDataType) => {
     if (coLeaders.length < 3 && !coLeaders.some(leader => leader.id === user.id)) {


### PR DESCRIPTION
## 🚩 관련 이슈

- close #948 

## 📋 작업 내용

- [x] 기능 구현

## 📌 PR Point

공동 모임장에 본인을 추가하여 모임 개설 신청을 할 시에, 서버 측에서 에러를 내도록 구성되어 있습니다.
이를 UX를 보존하며 해결하고자, 공동 모임장에 애초에 추가할 수 없도록 검색이 불가능하게 구현했습니다.
