### PR TITLE
QA: 협의 후 결정 여부에 따른 메시지 출력 여부 결정

### DIFF
--- a/src/components/page/detail/Information/constant.tsx
+++ b/src/components/page/detail/Information/constant.tsx
@@ -100,12 +100,13 @@ export const FlashDetailList = (detailData: GetFlashByIdResponse) => [
     ),
     Content: () => {
       const isSingleDay = detailData.flashTimingType === '당일';
+      const isPeriodNotDecided = detailData.flashTimingType.includes('협의 후 결정');
       return (
         <SDescription style={{ color: 'white' }}>
           {`${dayjs(detailData.activityStartDate).format('YYYY. MM. DD (dd)')}${
             isSingleDay ? '' : ` ~ ${dayjs(detailData.activityEndDate).format('YYYY. MM. DD (dd)')}`
           }`}
-          {isSingleDay && (
+          {isPeriodNotDecided && (
             <>
               <Divider />
               기간 중 협의 후 결정


### PR DESCRIPTION
## 🚩 관련 이슈

- close #issue_number

## 📋 작업 내용

- [x] 기능 구현
- [x] 페이지 구조화 및 스타일링

## 📌 PR Point

- chore 한 수정으로, 서버 응답 데이터에 협의 후 결정 워딩이 포함될 경우에만 '협의 후 결정' 을 출력시키도록 fix 하였습니다.

## 📸 스크린샷
