### PR TITLE
필요없는 any 지우기 (any 는 타입스크립트가 아니에요!!)

### DIFF
--- a/src/utils/gtm.ts
+++ b/src/utils/gtm.ts
@@ -2,7 +2,7 @@ const dataLayer =
   typeof window === 'undefined'
     ? undefined
     : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (window as any).dataLayer;
+      (window as typeof window & { dataLayer?: { event: string; page: string }[] }).dataLayer;
 
 export const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID;
 


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1000 
- (영광의 1000번째 이슈네요 ㅎㅎ)

## 📋 작업 내용

- [x] 필요없는 any 를 발견하여 지웠습니다! any 는 사실 타입스크립트가 아니고, 타입스크립트에서 자바스크립트를 쓸 수 있게끔 열어둔 탈출구에요. 그래서 any 는 피치못할 사정이 있는 경우, 하나의 함수 범위 내에서만 쓰는 것을 권장하고 있어요. 


## 📌 PR Point

- src/components/util/layout/Flex.tsx 파일에 보면 as any 를 쓰고 있는데요, 이 경우는 라이브러리 충돌 이슈로 any 를 쓰고 잘 관리하는 게 any 를 안 쓰는 것보다 훨씬 복잡도가 낮아지기 때문에 그냥 놔두었어요. 반환하는 값은 jsx 이기 때문에 어차피 any 가 아니라 하나의 함수 내에서만 쓰이는 경우라고 이해해주시면 좋을 것 같습니다!!

## 📸 스크린샷
