### PR TITLE
번쩍 개설 시 이미지 width 를 고정값으로 변경 (디자인 측 요청사항)

### DIFF
--- a/src/components/form/Flash/index.tsx
+++ b/src/components/form/Flash/index.tsx
@@ -473,12 +473,10 @@ const STitleField = styled('div', {
   width: '100%',
 });
 const SFileInputWrapper = styled('div', {
-  display: 'grid',
-  gridTemplateColumns: 'repeat(3, 1fr)',
-  gap: '16px',
+  width: '260px',
 
-  '@tablet': {
-    gridTemplateColumns: 'repeat(2, 1fr)',
+  '@mobile': {
+    width: '256px',
   },
 });
 const SApplicationFieldWrapper = styled('div', {


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1007 

## 📋 작업 내용

- [x] 가온이가 번쩍 개설 시에는 이미지 width 를 고정해달라고 요청주어서 요청 사항 반영합니다~! (기존에는 grid column 으로 되어 있었음.)

## 📌 PR Point

- 무슨 이유로 어떻게 코드를 변경했는지
- 어떤 위험이나 우려가 발견되었는지
- 어떤 부분에 리뷰어가 집중해야 하는지
- 개발하면서 어떤 점이 궁금했는지

## 📸 스크린샷
