### PR TITLE
모바일 환영태그 안 뜨도록 수정

### DIFF
--- a/src/components/page/detail/Information/InformationPanel.tsx
+++ b/src/components/page/detail/Information/InformationPanel.tsx
@@ -6,17 +6,23 @@ import { GetMeetingResponse } from '@api/API_LEGACY/meeting';
 import { FlashDetailList, MeetingDetailList } from '@components/page/detail/Information/constant';
 import { GetFlashByIdResponse } from '@api/flash';
 
+type DetailDataType = GetMeetingResponse | GetFlashByIdResponse;
+
 interface InformationPanelProps {
-  detailData: GetMeetingResponse | GetFlashByIdResponse;
+  detailData: DetailDataType;
 }
 
 const InformationPanel = ({ detailData }: InformationPanelProps) => {
   const { isMobile } = useDisplay();
   const tabRef = useRef<HTMLElement[]>([]);
-  const detailList =
-    detailData.category === '번쩍'
-      ? FlashDetailList(detailData as GetFlashByIdResponse)
-      : MeetingDetailList(detailData as GetMeetingResponse);
+
+  function isFlash(detailData: DetailDataType): detailData is GetFlashByIdResponse {
+    return detailData.category === '번쩍' && (detailData as GetFlashByIdResponse).welcomeMessageTypes !== undefined;
+  }
+
+  const detailList = isFlash(detailData)
+    ? FlashDetailList(detailData as GetFlashByIdResponse)
+    : MeetingDetailList(detailData as GetMeetingResponse);
   const [selectedTab, setSelectedTab] = useState(detailList[0]?.key);
 
   const handleChange = useCallback((text: string) => {
@@ -30,7 +36,8 @@ const InformationPanel = ({ detailData }: InformationPanelProps) => {
         <TabList text={selectedTab ?? ''} size="small" onChange={handleChange}>
           {detailList.map(
             ({ key, isValid }) =>
-              isValid && (
+              isValid &&
+              key && (
                 <TabList.Item key={key} text={key}>
                   {key}
                 </TabList.Item>

--- a/src/components/page/detail/Information/constant.tsx
+++ b/src/components/page/detail/Information/constant.tsx
@@ -64,75 +64,77 @@ export const MeetingDetailList = (detailData: GetMeetingResponse) => [
   },
 ];
 
-export const FlashDetailList = (detailData: GetFlashByIdResponse) => [
-  {
-    key: '환영 태그',
-    Title: () => (detailData?.welcomeMessageTypes.length ? <STitle>#환영 태그</STitle> : null),
-    Content: () => {
-      return detailData?.welcomeMessageTypes.length ? (
-        <STarget>
-          {detailData?.welcomeMessageTypes.map(tag => (
-            <Chip key={tag} style={{ boxShadow: 'none' }} active>
-              {tag}
-            </Chip>
-          ))}
-        </STarget>
-      ) : null;
+export const FlashDetailList = (detailData: GetFlashByIdResponse) => {
+  return [
+    {
+      key: detailData.welcomeMessageTypes?.length ? '환영 태그' : '',
+      Title: () => (detailData?.welcomeMessageTypes.length ? <STitle>#환영 태그</STitle> : null),
+      Content: () => {
+        return detailData?.welcomeMessageTypes.length ? (
+          <STarget>
+            {detailData?.welcomeMessageTypes.map(tag => (
+              <Chip key={tag} style={{ boxShadow: 'none' }} active>
+                {tag}
+              </Chip>
+            ))}
+          </STarget>
+        ) : null;
+      },
+      isValid: detailData?.welcomeMessageTypes,
     },
-    isValid: detailData?.welcomeMessageTypes,
-  },
-  {
-    key: '설명',
-    Title: () => <STitle>설명</STitle>,
-    Content: () => {
-      return <SDescription>{parseTextToLink(detailData?.desc)}</SDescription>;
+    {
+      key: '설명',
+      Title: () => <STitle>설명</STitle>,
+      Content: () => {
+        return <SDescription>{parseTextToLink(detailData?.desc)}</SDescription>;
+      },
+      isValid: detailData?.desc,
     },
-    isValid: detailData?.desc,
-  },
-  {
-    key: '진행일',
-    Title: () => (
-      <SIconTitleWrapper>
-        <SIconCalendar />
-        <STitle>진행일</STitle>
-      </SIconTitleWrapper>
-    ),
-    Content: () => {
-      const isSingleDay = detailData.flashTimingType === '당일';
-      const isPeriodNotDecided = detailData.flashTimingType.includes('협의 후 결정');
-      return (
-        <SDescription style={{ color: 'white' }}>
-          {`${dayjs(detailData.activityStartDate).format('YYYY. MM. DD (dd)')}${
-            isSingleDay ? '' : ` ~ ${dayjs(detailData.activityEndDate).format('YYYY. MM. DD (dd)')}`
-          }`}
-          {isPeriodNotDecided && (
-            <>
-              <Divider />
-              기간 중 협의 후 결정
-            </>
-          )}
-        </SDescription>
-      );
+    {
+      key: '진행일',
+      Title: () => (
+        <SIconTitleWrapper>
+          <SIconCalendar />
+          <STitle>진행일</STitle>
+        </SIconTitleWrapper>
+      ),
+      Content: () => {
+        const isSingleDay = detailData.flashTimingType === '당일';
+        const isPeriodNotDecided = detailData.flashTimingType.includes('협의 후 결정');
+        return (
+          <SDescription style={{ color: 'white' }}>
+            {`${dayjs(detailData.activityStartDate).format('YYYY. MM. DD (dd)')}${
+              isSingleDay ? '' : ` ~ ${dayjs(detailData.activityEndDate).format('YYYY. MM. DD (dd)')}`
+            }`}
+            {isPeriodNotDecided && (
+              <>
+                <Divider />
+                기간 중 협의 후 결정
+              </>
+            )}
+          </SDescription>
+        );
+      },
+      isValid: detailData.activityStartDate && detailData.activityEndDate,
     },
-    isValid: detailData.activityStartDate && detailData.activityEndDate,
-  },
-  {
-    key: '장소',
-    Title: () => (
-      <SIconTitleWrapper>
-        <SIconLocation />
-        <STitle>장소</STitle>
-      </SIconTitleWrapper>
-    ),
-    Content: () => (
-      <SDescription style={{ color: 'white' }}>{`${parsePlaceType(
-        detailData.flashPlaceType,
-        detailData.flashPlace
-      )}`}</SDescription>
-    ),
-    isValid: detailData.flashPlace,
-  },
-];
+    {
+      key: '장소',
+      Title: () => (
+        <SIconTitleWrapper>
+          <SIconLocation />
+          <STitle>장소</STitle>
+        </SIconTitleWrapper>
+      ),
+      Content: () => (
+        <SDescription style={{ color: 'white' }}>{`${parsePlaceType(
+          detailData.flashPlaceType,
+          detailData.flashPlace
+        )}`}</SDescription>
+      ),
+      isValid: detailData.flashPlace,
+    },
+  ];
+};
 
 const parsePlaceType = (placeType: string, place: string) => {
   switch (placeType) {

--- a/src/components/page/detail/Information/constant.tsx
+++ b/src/components/page/detail/Information/constant.tsx
@@ -67,7 +67,7 @@ export const MeetingDetailList = (detailData: GetMeetingResponse) => [
 export const FlashDetailList = (detailData: GetFlashByIdResponse) => {
   return [
     {
-      key: detailData.welcomeMessageTypes?.length ? '환영 태그' : '',
+      key: detailData.welcomeMessageTypes.length ? '환영 태그' : '',
       Title: () => (detailData?.welcomeMessageTypes.length ? <STitle>#환영 태그</STitle> : null),
       Content: () => {
         return detailData?.welcomeMessageTypes.length ? (


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1019 

## 📋 작업 내용

- [x] 모바일 환영태그 안 뜨도록 수정

## 📌 PR Point

detailData가 type DetailDataType = GetMeetingResponse | GetFlashByIdResponse; 2가지 타입일 수 있었습니다.
이로 인해, GetMeetingResponse로 추론되는 경우 welcomeMessageTypes는 존재하지 않는 필드가 되어버렸습니다.
단순하게 ?(옵셔널 체이닝)으로 해결할 수 있지만, 코드의 통일성 및 디버깅의 용이성을 위해 타입 가드를 작성했습니다.

