### PR TITLE
피드 개설시, mention bug QA 반영

### DIFF
--- a/src/components/feed/Modal/FeedCreateModal.tsx
+++ b/src/components/feed/Modal/FeedCreateModal.tsx
@@ -61,11 +61,14 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
     onSuccess: res => {
       queryClient.invalidateQueries(['getPosts']);
       alert('피드를 작성했습니다.');
-      mutatePostPostWithMention({
-        postId: res.postId,
-        orgIds: parseMentionedUserIds(formMethods.getValues().contents),
-        content: formMethods.getValues().contents,
-      });
+      const mentionedOrgIds = parseMentionedUserIds(formMethods.getValues().contents);
+      if (mentionedOrgIds.length > 0) {
+        mutatePostPostWithMention({
+          postId: res.postId,
+          orgIds: parseMentionedUserIds(formMethods.getValues().contents),
+          content: formMethods.getValues().contents,
+        });
+      }
       submitModal.handleModalClose();
       handleModalClose();
       open({

--- a/src/components/feed/Modal/FeedCreateModal.tsx
+++ b/src/components/feed/Modal/FeedCreateModal.tsx
@@ -65,7 +65,7 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
       if (mentionedOrgIds.length > 0) {
         mutatePostPostWithMention({
           postId: res.postId,
-          orgIds: parseMentionedUserIds(formMethods.getValues().contents),
+          orgIds: mentionedOrgIds,
           content: formMethods.getValues().contents,
         });
       }


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1039 

## 📋 작업 내용

- [x] orgIds 빈배열일 때, mention api 요청하지 않도록 수정


## 📌 PR Point

```typescript
const mentionedOrgIds = parseMentionedUserIds(formMethods.getValues().contents);
      if (mentionedOrgIds.length > 0) {
        mutatePostPostWithMention({
          postId: res.postId,
          orgIds: parseMentionedUserIds(formMethods.getValues().contents),
          content: formMethods.getValues().contents,
        });
      }
```

다음과 같이, mentioned 된 유저 id list 의 길이가 0이 아닐 때는 요청 보내지 않도록 조건문 걸었습니다

## 📸 스크린샷
