### PR TITLE
더보기 버튼(⋮) 작동 오류, 피드 삭제 기능 버그 수정 QA

### DIFF
--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -5,7 +5,13 @@ import { useQueryMyProfile } from '@api/API_LEGACY/user/hooks';
 import { api, apiV2 } from '@api/index';
 import { PostCommentWithMentionRequest } from '@api/mention';
 import { useMutationPostCommentWithMention } from '@api/mention/hooks';
-import { useInfinitePosts, useMutationPostLike, useMutationUpdateLike, useQueryGetPost } from '@api/post/hooks';
+import {
+  useInfinitePosts,
+  useMutationDeletePost,
+  useMutationPostLike,
+  useMutationUpdateLike,
+  useQueryGetPost,
+} from '@api/post/hooks';
 import LikeButton from '@components/@common/button/LikeButton';
 import ContentBlocker from '@components/blocker/ContentBlocker';
 import FeedActionButton from '@components/feed/FeedActionButton/FeedActionButton';
@@ -99,11 +105,27 @@ export default function PostPage() {
   };
 
   const { mutate: togglePostLike } = useMutationPostLike(query.id as string);
+  const { mutate: mutateDeletePost } = useMutationDeletePost();
 
-  const { mutate: mutateDeletePost } = useMutation({
-    mutationFn: postId => DELETE('/post/v2/{postId}', { params: { path: { postId: post!.id } } }),
-    onSuccess: () => router.replace(`/detail?id=${post?.meeting.id}`),
-  });
+  const handleDeleteSubPost = (postId: number) => {
+    mutateDeletePost(postId, {
+      onSuccess: () => {
+        overlay.close();
+        open({
+          icon: 'success',
+          content: '게시글을 삭제했습니다',
+        });
+      },
+      onError: error => {
+        const axiosError = error as AxiosError<{ errorCode: string }>;
+        overlay.close();
+        open({
+          icon: 'error',
+          content: axiosError?.response?.data?.errorCode as string,
+        });
+      },
+    });
+  };
 
   const { mutateAsync: mutateReportPost } = useMutation({
     mutationFn: (postId: number) =>
@@ -141,8 +163,6 @@ export default function PostPage() {
     ): comment is paths['/comment/v2']['get']['responses']['200']['content']['application/json;charset=UTF-8']['comments'][number] =>
       !!comment
   );
-
-  console.log({ comments });
 
   const handleClickComment = () => {
     const refCurrent = commentRef.current;
@@ -191,7 +211,10 @@ export default function PostPage() {
         Actions={FeedActionsContainer({
           postId: post.id,
           isMine: isMine,
-          handleDelete: mutateDeletePost,
+          handleDelete: () => {
+            mutateDeletePost(post.id);
+            router.replace(`/detail?id=${post.meeting.id}`);
+          },
           handleReport: handleConfirmReportPost({ postId: post.id, callback: close }),
           overlay: overlay,
         })}
@@ -274,7 +297,7 @@ export default function PostPage() {
                           Actions={FeedActionsContainer({
                             postId: post.id,
                             isMine: isMyFeed,
-                            handleDelete: mutateDeletePost,
+                            handleDelete: () => handleDeleteSubPost(post.id),
                             handleReport: handleConfirmReportPost({ postId: post.id, callback: close }),
                             overlay: overlay,
                           })}
@@ -317,7 +340,7 @@ export default function PostPage() {
                         Actions={FeedActionsContainer({
                           postId: post.id,
                           isMine: isMyFeed,
-                          handleDelete: mutateDeletePost,
+                          handleDelete: () => handleDeleteSubPost(post.id),
                           handleReport: handleConfirmReportPost({ postId: post.id, callback: close }),
                           overlay: overlay,
                         })}

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -35,6 +35,7 @@ import ReWriteIcon from '@assets/svg/comment-write.svg';
 import TrashIcon from '@assets/svg/trash.svg';
 import AlertIcon from '@assets/svg/alert-triangle.svg';
 import { AxiosError } from 'axios';
+import FeedActionsContainer from '@components/feed/FeedActionsContainer';
 
 export default function PostPage() {
   const commentRef = useRef<HTMLTextAreaElement | null>(null);
@@ -186,60 +187,13 @@ export default function PostPage() {
     <Container>
       <FeedPostViewer
         post={post}
-        // TODO: Actions 합성하는 부분 추상화 한번 더 하자. 너무 verbose 하다.
-        Actions={
-          isMine
-            ? [
-                <FeedActionButton
-                  onClick={() =>
-                    overlay.open(({ isOpen, close }) => (
-                      <FeedEditModal isModalOpened={isOpen} postId={String(post.id)} handleModalClose={close} />
-                    ))
-                  }
-                >
-                  <ReWriteIcon />
-                  수정
-                </FeedActionButton>,
-                <FeedActionButton
-                  onClick={() => {
-                    overlay.open(({ isOpen, close }) => (
-                      // eslint-disable-next-line prettier/prettier
-                      <ConfirmModal
-                        isModalOpened={isOpen}
-                        message="게시글을 삭제하시겠습니까?"
-                        cancelButton="돌아가기"
-                        confirmButton="삭제하기"
-                        handleModalClose={close}
-                        handleConfirm={mutateDeletePost}
-                      />
-                    ));
-                  }}
-                >
-                  <TrashIcon />
-                  삭제
-                </FeedActionButton>,
-              ]
-            : [
-                <FeedActionButton
-                  onClick={() => {
-                    overlay.open(({ isOpen, close }) => (
-                      // eslint-disable-next-line prettier/prettier
-                      <ConfirmModal
-                        isModalOpened={isOpen}
-                        message="게시글을 신고하시겠습니까?"
-                        cancelButton="돌아가기"
-                        confirmButton="신고하기"
-                        handleModalClose={close}
-                        handleConfirm={handleConfirmReportPost({ postId: post.id, callback: close })}
-                      />
-                    ));
-                  }}
-                >
-                  <AlertIcon />
-                  신고
-                </FeedActionButton>,
-              ]
-        }
+        Actions={FeedActionsContainer({
+          postId: post.id,
+          isMine: isMine,
+          handleDelete: mutateDeletePost,
+          handleReport: handleConfirmReportPost({ postId: post.id, callback: close }),
+          overlay: overlay,
+        })}
         CommentLikeSection={
           <FeedCommentLikeSection
             isLiked={post.isLiked}
@@ -316,63 +270,13 @@ export default function PostPage() {
                               onClickLike={handleClickLike(post.id)(mutateLike)}
                             />
                           }
-                          Actions={
-                            isMyFeed
-                              ? [
-                                  <FeedActionButton
-                                    onClick={() =>
-                                      overlay.open(({ isOpen, close }) => (
-                                        <FeedEditModal
-                                          isModalOpened={isOpen}
-                                          postId={String(post.id)}
-                                          handleModalClose={close}
-                                        />
-                                      ))
-                                    }
-                                  >
-                                    <ReWriteIcon />
-                                    수정
-                                  </FeedActionButton>,
-                                  <FeedActionButton
-                                    onClick={() => {
-                                      overlay.open(({ isOpen, close }) => (
-                                        // eslint-disable-next-line prettier/prettier
-                                        <ConfirmModal
-                                          isModalOpened={isOpen}
-                                          message="게시글을 삭제하시겠습니까?"
-                                          cancelButton="돌아가기"
-                                          confirmButton="삭제하기"
-                                          handleModalClose={close}
-                                          handleConfirm={mutateDeletePost}
-                                        />
-                                      ));
-                                    }}
-                                  >
-                                    <TrashIcon />
-                                    삭제
-                                  </FeedActionButton>,
-                                ]
-                              : [
-                                  <FeedActionButton
-                                    onClick={() => {
-                                      overlay.open(({ isOpen, close }) => (
-                                        // eslint-disable-next-line prettier/prettier
-                                        <ConfirmModal
-                                          isModalOpened={isOpen}
-                                          message="게시글을 신고하시겠습니까?"
-                                          cancelButton="돌아가기"
-                                          confirmButton="신고하기"
-                                          handleModalClose={close}
-                                          handleConfirm={handleConfirmReportPost({ postId: post.id, callback: close })}
-                                        />
-                                      ));
-                                    }}
-                                  >
-                                    <AlertIcon />
-                                    신고
-                                  </FeedActionButton>,
-                                ]
-                          }
+                          Actions={FeedActionsContainer({
+                            postId: post.id,
+                            isMine: isMyFeed,
+                            handleDelete: mutateDeletePost,
+                            handleReport: handleConfirmReportPost({ postId: post.id, callback: close }),
+                            overlay: overlay,
+                          })}
                         />
                       </Link>
                     )}
@@ -409,63 +313,13 @@ export default function PostPage() {
                             onClickLike={handleClickLike(post.id)(mutateLikeInAllPost)}
                           />
                         }
-                        Actions={
-                          isMyFeed
-                            ? [
-                                <FeedActionButton
-                                  onClick={() =>
-                                    overlay.open(({ isOpen, close }) => (
-                                      <FeedEditModal
-                                        isModalOpened={isOpen}
-                                        postId={String(post.id)}
-                                        handleModalClose={close}
-                                      />
-                                    ))
-                                  }
-                                >
-                                  <ReWriteIcon />
-                                  수정
-                                </FeedActionButton>,
-                                <FeedActionButton
-                                  onClick={() => {
-                                    overlay.open(({ isOpen, close }) => (
-                                      // eslint-disable-next-line prettier/prettier
-                                      <ConfirmModal
-                                        isModalOpened={isOpen}
-                                        message="게시글을 삭제하시겠습니까?"
-                                        cancelButton="돌아가기"
-                                        confirmButton="삭제하기"
-                                        handleModalClose={close}
-                                        handleConfirm={mutateDeletePost}
-                                      />
-                                    ));
-                                  }}
-                                >
-                                  <TrashIcon />
-                                  삭제
-                                </FeedActionButton>,
-                              ]
-                            : [
-                                <FeedActionButton
-                                  onClick={() => {
-                                    overlay.open(({ isOpen, close }) => (
-                                      // eslint-disable-next-line prettier/prettier
-                                      <ConfirmModal
-                                        isModalOpened={isOpen}
-                                        message="게시글을 신고하시겠습니까?"
-                                        cancelButton="돌아가기"
-                                        confirmButton="신고하기"
-                                        handleModalClose={close}
-                                        handleConfirm={handleConfirmReportPost({ postId: post.id, callback: close })}
-                                      />
-                                    ));
-                                  }}
-                                >
-                                  <AlertIcon />
-                                  신고
-                                </FeedActionButton>,
-                              ]
-                        }
+                        Actions={FeedActionsContainer({
+                          postId: post.id,
+                          isMine: isMyFeed,
+                          handleDelete: mutateDeletePost,
+                          handleReport: handleConfirmReportPost({ postId: post.id, callback: close }),
+                          overlay: overlay,
+                        })}
                       />
                     </Link>
                   )}

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -295,7 +295,7 @@ export default function PostPage() {
             <FeedList>
               {postsInMeeting?.map(post => {
                 if (!post) return;
-                const isMine = post.user.id === me?.id;
+                const isMyFeed = post.user.id === me?.id;
                 return (
                   <>
                     {post.isBlockedPost ? (
@@ -317,7 +317,7 @@ export default function PostPage() {
                             />
                           }
                           Actions={
-                            isMine
+                            isMyFeed
                               ? [
                                   <FeedActionButton
                                     onClick={() =>
@@ -387,7 +387,7 @@ export default function PostPage() {
           <FeedList>
             {allMeetingPosts?.map(post => {
               if (!post) return;
-              const isMine = post.user.id === me?.id;
+              const isMyFeed = post.user.id === me?.id;
               return (
                 <>
                   {post.isBlockedPost ? (
@@ -410,7 +410,7 @@ export default function PostPage() {
                           />
                         }
                         Actions={
-                          isMine
+                          isMyFeed
                             ? [
                                 <FeedActionButton
                                   onClick={() =>

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -14,15 +14,12 @@ import {
 } from '@api/post/hooks';
 import LikeButton from '@components/@common/button/LikeButton';
 import ContentBlocker from '@components/blocker/ContentBlocker';
-import FeedActionButton from '@components/feed/FeedActionButton/FeedActionButton';
 import FeedCommentContainer from '@components/feed/FeedCommentContainer/FeedCommentContainer';
 import FeedCommentInput from '@components/feed/FeedCommentInput/FeedCommentInput';
 import FeedCommentLikeSection from '@components/feed/FeedCommentLikeSection/FeedCommentLikeSection';
 import FeedPostViewer from '@components/feed/FeedPostViewer/FeedPostViewer';
 import { MentionContext } from '@components/feed/Mention/MentionContext';
-import FeedEditModal from '@components/feed/Modal/FeedEditModal';
 import Loader from '@components/@common/loader/Loader';
-import ConfirmModal from '@components/modal/ConfirmModal';
 import FeedItem from '@components/page/detail/Feed/FeedItem';
 import MeetingInfo from '@components/page/detail/Feed/FeedItem/MeetingInfo';
 import { TAKE_COUNT } from '@constants/feed';
@@ -37,9 +34,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import React, { useContext, useEffect, useRef } from 'react';
 import { styled } from 'stitches.config';
-import ReWriteIcon from '@assets/svg/comment-write.svg';
-import TrashIcon from '@assets/svg/trash.svg';
-import AlertIcon from '@assets/svg/alert-triangle.svg';
 import { AxiosError } from 'axios';
 import FeedActionsContainer from '@components/feed/FeedActionsContainer';
 
@@ -50,7 +44,7 @@ export default function PostPage() {
   const router = useRouter();
   const { isMobile } = useDisplay();
   const query = router.query;
-  const { POST, DELETE } = apiV2.get();
+  const { POST } = apiV2.get();
 
   const { data: me } = useQueryMyProfile();
 

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -295,6 +295,7 @@ export default function PostPage() {
             <FeedList>
               {postsInMeeting?.map(post => {
                 if (!post) return;
+                const isMine = post.user.id === me?.id;
                 return (
                   <>
                     {post.isBlockedPost ? (
@@ -386,6 +387,7 @@ export default function PostPage() {
           <FeedList>
             {allMeetingPosts?.map(post => {
               if (!post) return;
+              const isMine = post.user.id === me?.id;
               return (
                 <>
                   {post.isBlockedPost ? (

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -101,7 +101,7 @@ export default function PostPage() {
   const { mutate: togglePostLike } = useMutationPostLike(query.id as string);
 
   const { mutate: mutateDeletePost } = useMutation({
-    mutationFn: () => DELETE('/post/v2/{postId}', { params: { path: { postId: post!.id } } }),
+    mutationFn: postId => DELETE('/post/v2/{postId}', { params: { path: { postId: post!.id } } }),
     onSuccess: () => router.replace(`/detail?id=${post?.meeting.id}`),
   });
 
@@ -111,6 +111,7 @@ export default function PostPage() {
         paths['/post/v2/{postId}/report']['post']['responses']['201']['content']['application/json;charset=UTF-8']
       >(`/post/v2/${postId}/report`, {}),
   });
+
   const handleConfirmReportPost =
     ({ postId, callback }: { postId: number; callback: () => void }) =>
     async () => {

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -40,7 +40,7 @@ import FeedActionsContainer from '@components/feed/FeedActionsContainer';
 export default function PostPage() {
   const commentRef = useRef<HTMLTextAreaElement | null>(null);
   const overlay = useOverlay();
-  const { open } = useToast();
+  const { open, close } = useToast();
   const router = useRouter();
   const { isMobile } = useDisplay();
   const query = router.query;
@@ -137,14 +137,14 @@ export default function PostPage() {
           icon: 'success',
           content: '게시글을 신고했습니다',
         });
-        callback();
+        overlay.close();
       } catch (error) {
         const axiosError = error as AxiosError<{ errorCode: string }>;
         open({
           icon: 'error',
           content: axiosError?.response?.data?.errorCode as string,
         });
-        callback();
+        overlay.close();
         return;
       }
     };

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -1,8 +1,10 @@
 // import { paths } from '@/__generated__/schema';
 import { InfiniteData, useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { produce } from 'immer';
-import { deleteComment, getPost, getPosts, postLike } from '.';
+import { deleteComment, deletePost, getPost, getPosts, postLike } from '.';
 import { paths } from '@/__generated__/schema2';
+import { apiV2 } from '@/api';
+import { router } from 'next/client';
 
 export const useInfinitePosts = (take: number, meetingId?: number, enabled?: boolean) => {
   return useInfiniteQuery({
@@ -22,6 +24,17 @@ export const useInfinitePosts = (take: number, meetingId?: number, enabled?: boo
         pageParams: data.pageParams,
         total: data.pages[0]?.meta.itemCount,
       };
+    },
+  });
+};
+
+export const useMutationDeletePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => deletePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['getPosts']);
     },
   });
 };

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -1,10 +1,7 @@
-// import { paths } from '@/__generated__/schema';
 import { InfiniteData, useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { produce } from 'immer';
 import { deleteComment, deletePost, getPost, getPosts, postLike } from '.';
 import { paths } from '@/__generated__/schema2';
-import { apiV2 } from '@/api';
-import { router } from 'next/client';
 
 export const useInfinitePosts = (take: number, meetingId?: number, enabled?: boolean) => {
   return useInfiniteQuery({

--- a/src/api/post/index.ts
+++ b/src/api/post/index.ts
@@ -53,6 +53,5 @@ export const deleteComment = async (commentId: number) => {
 };
 
 export const deletePost = async (postId: number) => {
-  console.log(postId);
   return (await api.delete(`/post/v2/${postId}`)).data;
 };

--- a/src/api/post/index.ts
+++ b/src/api/post/index.ts
@@ -51,3 +51,8 @@ export const postLike = async (postId: number) => {
 export const deleteComment = async (commentId: number) => {
   return (await api.delete(`/comment/v2/${commentId}`)).data;
 };
+
+export const deletePost = async (postId: number) => {
+  console.log(postId);
+  return (await api.delete(`/post/v2/${postId}`)).data;
+};

--- a/src/api/post/index.ts
+++ b/src/api/post/index.ts
@@ -22,7 +22,7 @@ export const createPost = async (formData: FormCreateType) => {
   return data;
 };
 
-export const editPost = async (postId: string, formData: FormEditType) => {
+export const editPost = async (postId: number, formData: FormEditType) => {
   type editPostType =
     paths['/post/v2/{postId}']['put']['responses']['200']['content']['application/json;charset=UTF-8'];
   const { data } = await api.put<editPostType>(`/post/v2/${postId}`, formData);

--- a/src/components/feed/FeedActionsContainer/index.tsx
+++ b/src/components/feed/FeedActionsContainer/index.tsx
@@ -18,6 +18,11 @@ interface FeedActionsProps {
   };
 }
 
+interface openOverlayProps {
+  isOpen: boolean;
+  close: () => void;
+}
+
 const FeedActionsContainer = ({
   postId,
   isMine,
@@ -25,12 +30,16 @@ const FeedActionsContainer = ({
   handleReport,
   overlay,
 }: FeedActionsProps): React.ReactNode[] => {
+  const openOverlay = (Component: (props: openOverlayProps) => JSX.Element) => {
+    overlay.open(({ isOpen, close }) => <Component isOpen={isOpen} close={close} />);
+  };
+
   if (isMine) {
     return [
       <FeedActionButton
         onClick={() =>
-          overlay.open(({ isOpen, close }) => (
-            <FeedEditModal isModalOpened={isOpen} postId={postId} handleModalClose={close} />
+          openOverlay(({ isOpen, close }) => (
+            <FeedEditModal postId={postId} isModalOpened={isOpen} handleModalClose={close} />
           ))
         }
       >
@@ -39,7 +48,7 @@ const FeedActionsContainer = ({
       </FeedActionButton>,
       <FeedActionButton
         onClick={() => {
-          overlay.open(({ isOpen, close }) => (
+          openOverlay(({ isOpen, close }) => (
             <ConfirmModal
               isModalOpened={isOpen}
               message="게시글을 삭제하시겠습니까?"
@@ -60,7 +69,7 @@ const FeedActionsContainer = ({
   return [
     <FeedActionButton
       onClick={() => {
-        overlay.open(({ isOpen, close }) => (
+        openOverlay(({ isOpen, close }) => (
           <ConfirmModal
             isModalOpened={isOpen}
             message="게시글을 신고하시겠습니까?"

--- a/src/components/feed/FeedActionsContainer/index.tsx
+++ b/src/components/feed/FeedActionsContainer/index.tsx
@@ -41,7 +41,6 @@ const FeedActionsContainer = ({
       <FeedActionButton
         onClick={() => {
           overlay.open(({ isOpen, close }) => (
-            // eslint-disable-next-line prettier/prettier
             <ConfirmModal
               isModalOpened={isOpen}
               message="게시글을 삭제하시겠습니까?"
@@ -63,7 +62,6 @@ const FeedActionsContainer = ({
     <FeedActionButton
       onClick={() => {
         overlay.open(({ isOpen, close }) => (
-          // eslint-disable-next-line prettier/prettier
           <ConfirmModal
             isModalOpened={isOpen}
             message="게시글을 신고하시겠습니까?"

--- a/src/components/feed/FeedActionsContainer/index.tsx
+++ b/src/components/feed/FeedActionsContainer/index.tsx
@@ -6,7 +6,6 @@ import TrashIcon from '@assets/svg/trash.svg';
 import AlertIcon from '@assets/svg/alert-triangle.svg';
 import { CreateOverlayElement } from '@hooks/useOverlay/types';
 import React from 'react';
-import { TData } from 'memfs/lib/volume';
 
 interface FeedActionsProps {
   postId: number;

--- a/src/components/feed/FeedActionsContainer/index.tsx
+++ b/src/components/feed/FeedActionsContainer/index.tsx
@@ -5,6 +5,7 @@ import ReWriteIcon from '@assets/svg/comment-write.svg';
 import TrashIcon from '@assets/svg/trash.svg';
 import AlertIcon from '@assets/svg/alert-triangle.svg';
 import { CreateOverlayElement } from '@hooks/useOverlay/types';
+import React from 'react';
 
 interface FeedActionsProps {
   postId: number;

--- a/src/components/feed/FeedActionsContainer/index.tsx
+++ b/src/components/feed/FeedActionsContainer/index.tsx
@@ -30,7 +30,7 @@ const FeedActionsContainer = ({
       <FeedActionButton
         onClick={() =>
           overlay.open(({ isOpen, close }) => (
-            <FeedEditModal isModalOpened={isOpen} postId={String(postId)} handleModalClose={close} />
+            <FeedEditModal isModalOpened={isOpen} postId={postId} handleModalClose={close} />
           ))
         }
       >

--- a/src/components/feed/FeedActionsContainer/index.tsx
+++ b/src/components/feed/FeedActionsContainer/index.tsx
@@ -1,0 +1,82 @@
+import FeedActionButton from '@components/feed/FeedActionButton/FeedActionButton';
+import FeedEditModal from '@components/feed/Modal/FeedEditModal';
+import ConfirmModal from '@components/modal/ConfirmModal';
+import ReWriteIcon from '@assets/svg/comment-write.svg';
+import TrashIcon from '@assets/svg/trash.svg';
+import AlertIcon from '@assets/svg/alert-triangle.svg';
+import { CreateOverlayElement } from '@hooks/useOverlay/types';
+
+interface FeedActionsProps {
+  postId: number;
+  isMine: boolean;
+  handleDelete: () => void;
+  handleReport: () => void;
+  overlay: {
+    open: (overlayElement: CreateOverlayElement) => void;
+    close: () => void;
+  };
+}
+
+const FeedActionsContainer = ({
+  postId,
+  isMine,
+  handleDelete,
+  handleReport,
+  overlay,
+}: FeedActionsProps): React.ReactNode[] => {
+  if (isMine) {
+    return [
+      <FeedActionButton
+        onClick={() =>
+          overlay.open(({ isOpen, close }) => (
+            <FeedEditModal isModalOpened={isOpen} postId={String(postId)} handleModalClose={close} />
+          ))
+        }
+      >
+        <ReWriteIcon />
+        수정
+      </FeedActionButton>,
+      <FeedActionButton
+        onClick={() => {
+          overlay.open(({ isOpen, close }) => (
+            // eslint-disable-next-line prettier/prettier
+            <ConfirmModal
+              isModalOpened={isOpen}
+              message="게시글을 삭제하시겠습니까?"
+              cancelButton="돌아가기"
+              confirmButton="삭제하기"
+              handleModalClose={close}
+              handleConfirm={handleDelete}
+            />
+          ));
+        }}
+      >
+        <TrashIcon />
+        삭제
+      </FeedActionButton>,
+    ];
+  }
+
+  return [
+    <FeedActionButton
+      onClick={() => {
+        overlay.open(({ isOpen, close }) => (
+          // eslint-disable-next-line prettier/prettier
+          <ConfirmModal
+            isModalOpened={isOpen}
+            message="게시글을 신고하시겠습니까?"
+            cancelButton="돌아가기"
+            confirmButton="신고하기"
+            handleModalClose={close}
+            handleConfirm={handleReport}
+          />
+        ));
+      }}
+    >
+      <AlertIcon />
+      신고
+    </FeedActionButton>,
+  ];
+};
+
+export default FeedActionsContainer;

--- a/src/components/feed/FeedActionsContainer/index.tsx
+++ b/src/components/feed/FeedActionsContainer/index.tsx
@@ -6,6 +6,7 @@ import TrashIcon from '@assets/svg/trash.svg';
 import AlertIcon from '@assets/svg/alert-triangle.svg';
 import { CreateOverlayElement } from '@hooks/useOverlay/types';
 import React from 'react';
+import { TData } from 'memfs/lib/volume';
 
 interface FeedActionsProps {
   postId: number;

--- a/src/components/feed/Modal/FeedEditModal.tsx
+++ b/src/components/feed/Modal/FeedEditModal.tsx
@@ -19,12 +19,12 @@ const DevTool = dynamic(() => import('@hookform/devtools').then(module => module
 });
 
 interface EditModal extends ModalContainerProps {
-  postId: string;
+  postId: number;
 }
 
 function FeedEditModal({ isModalOpened, postId, handleModalClose }: EditModal) {
   const queryClient = useQueryClient();
-  const { data: postData } = useQueryGetPost(postId);
+  const { data: postData } = useQueryGetPost(String(postId));
   const exitModal = useModal();
   const submitModal = useModal();
   const { data: me } = useQueryMyProfile();

--- a/src/components/page/detail/Feed/FeedPanel.tsx
+++ b/src/components/page/detail/Feed/FeedPanel.tsx
@@ -58,7 +58,7 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
   const { mutate: mutateLike } = useMutationUpdateLike(TAKE_COUNT, Number(meetingId));
 
   const { mutate: mutateDeletePost } = useMutation({
-    mutationFn: postId => DELETE('/post/v2/{postId}', { params: { path: { postId: postId } } }),
+    mutationFn: postId => DELETE('/post/v2/{postId}', { params: { path: { postId: postId! } } }),
     onSuccess: () => {
       queryClient.invalidateQueries(['getPosts']);
       feedCreateOverlay.close();

--- a/src/components/page/detail/Feed/FeedPanel.tsx
+++ b/src/components/page/detail/Feed/FeedPanel.tsx
@@ -29,6 +29,7 @@ import { api, apiV2 } from '@/api';
 import { AxiosError } from 'axios';
 import { paths } from '@/__generated__/schema2';
 import { useToast } from '@sopt-makers/ui';
+import FeedActionsContainer from '@components/feed/FeedActionsContainer';
 
 interface FeedPanelProps {
   isMember: boolean;
@@ -150,59 +151,13 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
                   location: router.pathname,
                 })
               }
-              Actions={
-                isMyPost
-                  ? [
-                      <FeedActionButton
-                        onClick={() =>
-                          feedCreateOverlay.open(({ isOpen, close }) => (
-                            <FeedEditModal isModalOpened={isOpen} postId={String(post.id)} handleModalClose={close} />
-                          ))
-                        }
-                      >
-                        <ReWriteIcon />
-                        수정
-                      </FeedActionButton>,
-                      <FeedActionButton
-                        onClick={() => {
-                          feedCreateOverlay.open(({ isOpen, close }) => (
-                            // eslint-disable-next-line prettier/prettier
-                            <ConfirmModal
-                              isModalOpened={isOpen}
-                              message="게시글을 삭제하시겠습니까?"
-                              cancelButton="돌아가기"
-                              confirmButton="삭제하기"
-                              handleModalClose={close}
-                              handleConfirm={() => mutateDeletePost(post.id)}
-                            />
-                          ));
-                        }}
-                      >
-                        <TrashIcon />
-                        삭제
-                      </FeedActionButton>,
-                    ]
-                  : [
-                      <FeedActionButton
-                        onClick={() => {
-                          feedCreateOverlay.open(({ isOpen, close }) => (
-                            // eslint-disable-next-line prettier/prettier
-                            <ConfirmModal
-                              isModalOpened={isOpen}
-                              message="게시글을 신고하시겠습니까?"
-                              cancelButton="돌아가기"
-                              confirmButton="신고하기"
-                              handleModalClose={close}
-                              handleConfirm={handleConfirmReportPost({ postId: post.id, callback: close })}
-                            />
-                          ));
-                        }}
-                      >
-                        <AlertIcon />
-                        신고
-                      </FeedActionButton>,
-                    ]
-              }
+              Actions={FeedActionsContainer({
+                postId: post.id,
+                isMine: isMyPost,
+                handleDelete: () => mutateDeletePost(post.id),
+                handleReport: () => handleConfirmReportPost({ postId: post.id, callback: close }),
+                overlay: feedCreateOverlay,
+              })}
             />
           </Link>
         )}

--- a/src/components/page/detail/Feed/FeedPanel.tsx
+++ b/src/components/page/detail/Feed/FeedPanel.tsx
@@ -1,6 +1,6 @@
 import { ampli } from '@/ampli';
 import { useQueryGetMeeting } from '@api/API_LEGACY/meeting/hooks';
-import { useInfinitePosts, useMutationUpdateLike, useQueryGetPost } from '@api/post/hooks';
+import { useInfinitePosts, useMutationUpdateLike } from '@api/post/hooks';
 import { useQueryMyProfile } from '@api/API_LEGACY/user/hooks';
 import LikeButton from '@components/@common/button/LikeButton';
 import FeedCreateModal from '@components/feed/Modal/FeedCreateModal';
@@ -28,6 +28,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api, apiV2 } from '@/api';
 import { AxiosError } from 'axios';
 import { paths } from '@/__generated__/schema2';
+import { useToast } from '@sopt-makers/ui';
 
 interface FeedPanelProps {
   isMember: boolean;
@@ -38,8 +39,9 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
   const meetingId = router.query.id as string;
   const feedCreateOverlay = useOverlay();
   const { ref, inView } = useInView();
-  const { POST, DELETE } = apiV2.get();
+  const { DELETE } = apiV2.get();
   const queryClient = useQueryClient();
+  const { open } = useToast();
 
   const { isMobile, isTablet } = useDisplay();
   const { data: me } = useQueryMyProfile();
@@ -54,8 +56,6 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
 
   const { data: meeting } = useQueryGetMeeting({ params: { id: meetingId } });
   const { mutate: mutateLike } = useMutationUpdateLike(TAKE_COUNT, Number(meetingId));
-
-  console.log(postsData);
 
   const { mutate: mutateDeletePost } = useMutation({
     mutationFn: postId => DELETE('/post/v2/{postId}', { params: { path: { postId: postId } } }),

--- a/src/components/page/detail/Feed/FeedPanel.tsx
+++ b/src/components/page/detail/Feed/FeedPanel.tsx
@@ -1,6 +1,6 @@
 import { ampli } from '@/ampli';
 import { useQueryGetMeeting } from '@api/API_LEGACY/meeting/hooks';
-import { useInfinitePosts, useMutationUpdateLike } from '@api/post/hooks';
+import { useInfinitePosts, useMutationUpdateLike, useQueryGetPost } from '@api/post/hooks';
 import { useQueryMyProfile } from '@api/API_LEGACY/user/hooks';
 import LikeButton from '@components/@common/button/LikeButton';
 import FeedCreateModal from '@components/feed/Modal/FeedCreateModal';
@@ -11,13 +11,23 @@ import { useOverlay } from '@hooks/useOverlay/Index';
 import { useScrollRestorationAfterLoading } from '@hooks/useScrollRestoration';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { styled } from 'stitches.config';
 import EmptyView from './EmptyView';
 import FeedItem from './FeedItem';
 import MobileFeedListSkeleton from './Skeleton/MobileFeedListSkeleton';
 import ContentBlocker from '@components/blocker/ContentBlocker';
+import FeedActionButton from '@components/feed/FeedActionButton/FeedActionButton';
+import FeedEditModal from '@components/feed/Modal/FeedEditModal';
+import ReWriteIcon from '@assets/svg/comment-write.svg';
+import ConfirmModal from '@components/modal/ConfirmModal';
+import TrashIcon from '@assets/svg/trash.svg';
+import AlertIcon from '@assets/svg/alert-triangle.svg';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api, apiV2 } from '@/api';
+import { AxiosError } from 'axios';
+import { paths } from '@/__generated__/schema2';
 
 interface FeedPanelProps {
   isMember: boolean;
@@ -28,6 +38,8 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
   const meetingId = router.query.id as string;
   const feedCreateOverlay = useOverlay();
   const { ref, inView } = useInView();
+  const { POST, DELETE } = apiV2.get();
+  const queryClient = useQueryClient();
 
   const { isMobile, isTablet } = useDisplay();
   const { data: me } = useQueryMyProfile();
@@ -39,8 +51,19 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
     isLoading,
   } = useInfinitePosts(TAKE_COUNT, Number(meetingId), !!meetingId);
   useScrollRestorationAfterLoading(isLoading);
+
   const { data: meeting } = useQueryGetMeeting({ params: { id: meetingId } });
   const { mutate: mutateLike } = useMutationUpdateLike(TAKE_COUNT, Number(meetingId));
+
+  console.log(postsData);
+
+  const { mutate: mutateDeletePost } = useMutation({
+    mutationFn: postId => DELETE('/post/v2/{postId}', { params: { path: { postId: postId } } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['getPosts']);
+      feedCreateOverlay.close();
+    },
+  });
 
   const isEmpty = !postsData?.pages[0];
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -63,6 +86,34 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
     ampli.clickFeedlistLike({ location: router.pathname });
   };
 
+  const { mutateAsync: mutateReportPost } = useMutation({
+    mutationFn: (postId: number) =>
+      api.post<
+        paths['/post/v2/{postId}/report']['post']['responses']['201']['content']['application/json;charset=UTF-8']
+      >(`/post/v2/${postId}/report`, {}),
+  });
+
+  const handleConfirmReportPost =
+    ({ postId, callback }: { postId: number; callback: () => void }) =>
+    async () => {
+      try {
+        await mutateReportPost(postId);
+        open({
+          icon: 'success',
+          content: '게시글을 신고했습니다',
+        });
+        callback();
+      } catch (error) {
+        const axiosError = error as AxiosError<{ errorCode: string }>;
+        open({
+          icon: 'error',
+          content: axiosError?.response?.data?.errorCode as string,
+        });
+        callback();
+        return;
+      }
+    };
+
   useEffect(() => {
     if (inView && hasNextPage) {
       fetchNextPage();
@@ -71,6 +122,7 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
 
   const renderedPosts = postsData?.pages.map(post => {
     if (!post) return;
+    const isMyPost = me?.id === post.user.id;
     return (
       <>
         {post.isBlockedPost ? (
@@ -97,6 +149,59 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
                   platform_type: isMobile ? 'MO' : 'PC',
                   location: router.pathname,
                 })
+              }
+              Actions={
+                isMyPost
+                  ? [
+                      <FeedActionButton
+                        onClick={() =>
+                          feedCreateOverlay.open(({ isOpen, close }) => (
+                            <FeedEditModal isModalOpened={isOpen} postId={String(post.id)} handleModalClose={close} />
+                          ))
+                        }
+                      >
+                        <ReWriteIcon />
+                        수정
+                      </FeedActionButton>,
+                      <FeedActionButton
+                        onClick={() => {
+                          feedCreateOverlay.open(({ isOpen, close }) => (
+                            // eslint-disable-next-line prettier/prettier
+                            <ConfirmModal
+                              isModalOpened={isOpen}
+                              message="게시글을 삭제하시겠습니까?"
+                              cancelButton="돌아가기"
+                              confirmButton="삭제하기"
+                              handleModalClose={close}
+                              handleConfirm={() => mutateDeletePost(post.id)}
+                            />
+                          ));
+                        }}
+                      >
+                        <TrashIcon />
+                        삭제
+                      </FeedActionButton>,
+                    ]
+                  : [
+                      <FeedActionButton
+                        onClick={() => {
+                          feedCreateOverlay.open(({ isOpen, close }) => (
+                            // eslint-disable-next-line prettier/prettier
+                            <ConfirmModal
+                              isModalOpened={isOpen}
+                              message="게시글을 신고하시겠습니까?"
+                              cancelButton="돌아가기"
+                              confirmButton="신고하기"
+                              handleModalClose={close}
+                              handleConfirm={handleConfirmReportPost({ postId: post.id, callback: close })}
+                            />
+                          ));
+                        }}
+                      >
+                        <AlertIcon />
+                        신고
+                      </FeedActionButton>,
+                    ]
               }
             />
           </Link>

--- a/src/components/page/list/Advertisement/index.tsx
+++ b/src/components/page/list/Advertisement/index.tsx
@@ -92,11 +92,7 @@ const RenderPostsWithAds = () => {
                               <FeedActionButton
                                 onClick={() =>
                                   overlay.open(({ isOpen, close }) => (
-                                    <FeedEditModal
-                                      isModalOpened={isOpen}
-                                      postId={String(post.id)}
-                                      handleModalClose={close}
-                                    />
+                                    <FeedEditModal isModalOpened={isOpen} postId={post.id} handleModalClose={close} />
                                   ))
                                 }
                               >
@@ -181,11 +177,7 @@ const RenderPostsWithAds = () => {
                               <FeedActionButton
                                 onClick={() =>
                                   overlay.open(({ isOpen, close }) => (
-                                    <FeedEditModal
-                                      isModalOpened={isOpen}
-                                      postId={String(post.id)}
-                                      handleModalClose={close}
-                                    />
+                                    <FeedEditModal isModalOpened={isOpen} postId={post.id} handleModalClose={close} />
                                   ))
                                 }
                               >
@@ -273,11 +265,7 @@ const RenderPostsWithAds = () => {
                               <FeedActionButton
                                 onClick={() =>
                                   overlay.open(({ isOpen, close }) => (
-                                    <FeedEditModal
-                                      isModalOpened={isOpen}
-                                      postId={String(post.id)}
-                                      handleModalClose={close}
-                                    />
+                                    <FeedEditModal isModalOpened={isOpen} postId={post.id} handleModalClose={close} />
                                   ))
                                 }
                               >
@@ -362,11 +350,7 @@ const RenderPostsWithAds = () => {
                               <FeedActionButton
                                 onClick={e => {
                                   overlay.open(({ isOpen, close }) => (
-                                    <FeedEditModal
-                                      isModalOpened={isOpen}
-                                      postId={String(post.id)}
-                                      handleModalClose={close}
-                                    />
+                                    <FeedEditModal isModalOpened={isOpen} postId={post.id} handleModalClose={close} />
                                   ));
                                 }}
                               >


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1041 

## 📋 작업 내용
- [x] 모달 오류 체크
- [x] [피드 detail 페이지] 게시물 isMine 과, 최신피드및 다른 피드  isMine 분리
- [x] [모임 detail 페이지] 모달 안 뜨는 오류 수정 
- [x] [모임 detail 페이지] 게시물 삭제 후에 쿼리 재로드 

## 📌 PR Point

### 피드 삭제하는 부분 버그 개선

피드 삭제하는 부분 말씀드렸다싶이 postId 에 따라 삭제되는 로직이 없어서 수정했습니다. 
하면서 mutation 로직이 ui 그리는 부분에 직접적으로 구현이 되어 있어서, 어떻게 관리할까 고민하다가
분리 했습니다

내용을 정리하자면,
1. 피드 상세 페이지에서 해당 피드를 삭제하면 모임 페이지로 redirect.
2. 피드 하단에 있는 다른 피드 삭제시 Toast 뜨고, 쿼리 무효화 하도록 수정했습니다 !




### TODO : Actions 합성하는 부분 추상화 한번 더 하자. 너무 verbose 하다. => 리펙토링 했습니다 

![스크린샷 2025-03-10 23 00 33](https://github.com/user-attachments/assets/18947570-22b5-411f-b8c5-89ebe0ea9382)

과거 크루 선배님이 적어두신 TODO 리펙토링 완입니다 !

FeedActionsContainer 로 렌더링 합니다.
return type 은 ReactNode list 라서, 컴포넌트로 구현하지 못하고 함수 return 으로 구현하였습니다.

```typescript
Actions={FeedActionsContainer({
          postId: post.id,
          isMine: isMine,
          handleDelete: mutateDeletePost,
          handleReport: handleConfirmReportPost({ postId: post.id, callback: close }),
          overlay: overlay,
        })}
```
=> 다음과 같이 선언하면, isMine 값을 가져와서 true 이면 수정/삭제 모달이 뜨고, false 이면 신고 모달이 뜹니다.


### [모임 detail 페이지] 모달 안 뜨는 오류 수정 
다른 QA 로 올라온 사항인데, 해당 브랜치에서 두가지 한번에 처리 했습니다
모임 상세 페이지에 있는 피드 ... (더보기 버튼)을 눌러도 모달이 이렇게 안 뜨는 문제가 있었는데, 해당 문제 해결했습니다

모달이 아예 Actions props 로 전달되고 있지 않았습니다
-> Actions 연결하고,
뜨는 피드에 따른
1. 피드 수정 api
4. 피드 삭제 api
5. 피드 신고 api 
연결되도록 수정했습니다 

위에서 TODO로 리펙토링 한 부분을 (ACtions 중복 코드)
해당 QA 에도 적용 했씁니다 ~~


### 모달 오류 체크
체크해보면서 두가지 문제사항(🚨) 을 파악했습니다. 

1. 내 피드 상세페이지 하단에 “SOPT 모임들의 최신 피드”의 더보기는 모두 모달이 뜸

![1](https://github.com/user-attachments/assets/1c332de5-21f2-441f-8a64-b24d22c0ce7d)

<br />

6. 내 피드 상세페이지 하단에 “SOPT 모임들의 최신 피드”가  **남의 피드** 일 때 정상적으로 모달이 뜸 

 **→  🚨 이것도 남의 피드이기 때문에, 모달이 뜨면 안된다고 판단했습니다.**

![2](https://github.com/user-attachments/assets/1bb6f740-f2af-48f4-8c7f-7cadf6923a3c)

<br />

7.  🚨 남의 피드 상세페이지 하단에 “SOPT 모임들의 최신 피드” 에 뜬 **내 피드**의  삭제 모달이 안뜨는 것이 문제라고 판단했습니다. 

![3](https://github.com/user-attachments/assets/5e238bd3-62e7-4c40-be76-b31df778ec4b)

<br />

### 오류 개선

`const isMine = post.*user*.*id* === me?.id;`

→ 해당 코드에서 확인하는 것은,
현재 페이지(=피드)를 쓴 유저가 현재 로그인한 유저냐? 를 확인합니다. (= **현재 페이지(=피드)가 내가 쓴 피드인가?**)


근데, item(피드 한 개) 에서 [삭제/신고] 모달이 떠야 되는 상황을 정리해보면,

1. 현재 페이지(=피드)가 내가 쓴 피드는 아니지만, 해당 피드 하단에 뜬 “최신 피드” 가 내 것이라면, [삭제/신고] 모달이 떠야 함.
2. 현재 페이지(=피드)가 내가 쓴 피드이지만, 해당 피드 하단에 뜬 “최신 피드”가 내 것이 아니라면, [삭제/신고] 모달이 떠야 함.

그래서 결론적으로 isMine 은 **현재 페이지(=게시물) 가 내 게시물이냐**를 확인하는 것이 아니라,

✨ 이 게시물의 **하단에 있는 list 의 각 요소,즉 피드 하나하나가 내 것인지 아닌지**를 확인해서 모달을 렌더링 하는 로직으로 수정해야한다고 판단했습니다..

맞는지 한번 확인해주시면 감사합니다 !! 


## 📸 스크린샷

내 피드에만 삭제/신고 모달 뜨는 것 확인했습니다!
