### PR TITLE
불필요한 API 호출 방지를 위한 flash / meeting 컴포넌트 분리

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @borimong @j-nary @ocahs9
+*       @j-nary @minjeoong

--- a/.github/workflows/AutomaticAssignReviewer.yml
+++ b/.github/workflows/AutomaticAssignReviewer.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: hkusu/review-assign-action@v1
         with:
           assignees: ${{ github.actor }} # assign pull request author
-          reviewers: borimong, j-nary, ocahs9  # if draft, assigned when draft is released
+          reviewers: j-nary, minjeoong  # if draft, assigned when draft is released

--- a/pages/detail/flash/index.tsx
+++ b/pages/detail/flash/index.tsx
@@ -1,143 +1,18 @@
-import Carousel from '@components/page/detail/Carousel';
-import { styled } from 'stitches.config';
-import {
-  useMutationDeleteMeeting,
-  useMutationPostApplication,
-  useMutationDeleteApplication,
-} from '@api/API_LEGACY/meeting/hooks';
 import { useRouter } from 'next/router';
-import Loader from '@components/@common/loader/Loader';
-import InformationPanel from '@components/page/detail/Information/InformationPanel';
-import { Tab } from '@headlessui/react';
-import FeedPanel from '@components/page/detail/Feed/FeedPanel';
-import { Fragment, useState } from 'react';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
-import MeetingController from '@components/page/detail/MeetingController';
 import { useFlashByIdQuery } from '@api/flash/hook';
-import KakaoFloatingButton from '@components/FloatingButton/kakaoFloatingButton/KakaoFloatingButton';
+import CommonDetail from '@components/page/detail';
+import { GetFlashByIdResponse } from '@api/flash';
 
 dayjs.locale('ko');
-
-const enum SelectedTab {
-  INFORMATION,
-  FEED,
-}
 
 const DetailFlashPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
   const { data: flashData } = useFlashByIdQuery({ meetingId: +id });
-  const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
-  const { mutate: mutatePostApplication } = useMutationPostApplication({});
-  const { mutate: mutateDeleteApplication } = useMutationDeleteApplication({});
-  const [selectedIndex, setSelectedIndex] = useState(SelectedTab.INFORMATION);
 
-  if (!flashData) {
-    return (
-      <>
-        <Loader />
-        <div style={{ position: 'fixed', bottom: '2%', right: '5%' }}>
-          <KakaoFloatingButton />
-        </div>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <SDetailPage>
-        <Carousel imageList={flashData?.imageURL} />
-        <MeetingController
-          detailData={flashData}
-          mutateMeetingDeletion={mutateDeleteMeeting}
-          mutateApplication={mutatePostApplication}
-          mutateApplicationDeletion={mutateDeleteApplication}
-        />
-        <Tab.Group selectedIndex={selectedIndex} onChange={index => setSelectedIndex(index)}>
-          <STabList>
-            <Tab as={Fragment}>
-              <STabButton isSelected={selectedIndex === SelectedTab.INFORMATION}>모임 안내</STabButton>
-            </Tab>
-            <Tab as={Fragment}>
-              <STabButton isSelected={selectedIndex === SelectedTab.FEED}>피드</STabButton>
-            </Tab>
-          </STabList>
-          <Tab.Panels>
-            <Tab.Panel>
-              <InformationPanel detailData={flashData} />
-            </Tab.Panel>
-            <Tab.Panel>
-              <FeedPanel isMember={flashData?.approved || flashData?.host} />
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-      </SDetailPage>
-      <div style={{ position: 'fixed', bottom: '2%', right: '5%' }}>
-        <KakaoFloatingButton />
-      </div>
-    </>
-  );
+  return <CommonDetail detailData={flashData as GetFlashByIdResponse} />;
 };
 
 export default DetailFlashPage;
-
-const SDetailPage = styled('div', {
-  mb: '$374',
-
-  '@media (max-width: 768px)': {
-    mb: '$122',
-  },
-});
-
-const STabList = styled('div', {
-  display: 'flex',
-
-  '@media (max-width: 768px)': {
-    width: 'calc(100% + 40px)',
-    marginLeft: '-20px',
-  },
-
-  '@media (max-width: 414px)': {
-    width: 'calc(100% + 32px)',
-    marginLeft: '-16px',
-  },
-});
-
-const STabButton = styled('button', {
-  pb: '$24',
-  mr: '$32',
-  fontStyle: 'H1',
-  color: '$gray500',
-
-  '&:hover': {
-    color: '$gray10',
-  },
-
-  '@media (max-width: 768px)': {
-    fontStyle: 'T3',
-    padding: '$16 0',
-    mr: '$0',
-    flex: '1',
-    textAlign: 'center',
-  },
-
-  variants: {
-    isSelected: {
-      true: {
-        color: '$gray10',
-        borderBottom: `4px solid $gray10`,
-        '@media (max-width: 768px)': {
-          borderWidth: '2px',
-        },
-      },
-      false: {
-        color: '$gray500',
-        paddingBottom: '$28',
-        '@media (max-width: 768px)': {
-          paddingBottom: '$18',
-        },
-      },
-    },
-  },
-});

--- a/pages/detail/flash/index.tsx
+++ b/pages/detail/flash/index.tsx
@@ -4,7 +4,6 @@ import {
   useMutationDeleteMeeting,
   useMutationPostApplication,
   useMutationDeleteApplication,
-  useQueryGetMeeting,
 } from '@api/API_LEGACY/meeting/hooks';
 import { useRouter } from 'next/router';
 import Loader from '@components/@common/loader/Loader';
@@ -15,6 +14,7 @@ import { Fragment, useState } from 'react';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
 import MeetingController from '@components/page/detail/MeetingController';
+import { useFlashByIdQuery } from '@api/flash/hook';
 import KakaoFloatingButton from '@components/FloatingButton/kakaoFloatingButton/KakaoFloatingButton';
 
 dayjs.locale('ko');
@@ -24,16 +24,16 @@ const enum SelectedTab {
   FEED,
 }
 
-const DetailPage = () => {
+const DetailFlashPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
-  const { data: meetingData } = useQueryGetMeeting({ params: { id } });
+  const { data: flashData } = useFlashByIdQuery({ meetingId: +id });
   const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
   const { mutate: mutatePostApplication } = useMutationPostApplication({});
   const { mutate: mutateDeleteApplication } = useMutationDeleteApplication({});
   const [selectedIndex, setSelectedIndex] = useState(SelectedTab.INFORMATION);
 
-  if (!meetingData) {
+  if (!flashData) {
     return (
       <>
         <Loader />
@@ -47,9 +47,9 @@ const DetailPage = () => {
   return (
     <>
       <SDetailPage>
-        <Carousel imageList={meetingData?.imageURL} />
+        <Carousel imageList={flashData?.imageURL} />
         <MeetingController
-          detailData={meetingData}
+          detailData={flashData}
           mutateMeetingDeletion={mutateDeleteMeeting}
           mutateApplication={mutatePostApplication}
           mutateApplicationDeletion={mutateDeleteApplication}
@@ -65,10 +65,10 @@ const DetailPage = () => {
           </STabList>
           <Tab.Panels>
             <Tab.Panel>
-              <InformationPanel detailData={meetingData} />
+              <InformationPanel detailData={flashData} />
             </Tab.Panel>
             <Tab.Panel>
-              <FeedPanel isMember={meetingData?.approved || meetingData?.host} />
+              <FeedPanel isMember={flashData?.approved || flashData?.host} />
             </Tab.Panel>
           </Tab.Panels>
         </Tab.Group>
@@ -80,7 +80,7 @@ const DetailPage = () => {
   );
 };
 
-export default DetailPage;
+export default DetailFlashPage;
 
 const SDetailPage = styled('div', {
   mb: '$374',

--- a/pages/detail/index.tsx
+++ b/pages/detail/index.tsx
@@ -1,143 +1,18 @@
-import Carousel from '@components/page/detail/Carousel';
-import { styled } from 'stitches.config';
-import {
-  useMutationDeleteMeeting,
-  useMutationPostApplication,
-  useMutationDeleteApplication,
-  useQueryGetMeeting,
-} from '@api/API_LEGACY/meeting/hooks';
+import { useQueryGetMeeting } from '@api/API_LEGACY/meeting/hooks';
 import { useRouter } from 'next/router';
-import Loader from '@components/@common/loader/Loader';
-import InformationPanel from '@components/page/detail/Information/InformationPanel';
-import { Tab } from '@headlessui/react';
-import FeedPanel from '@components/page/detail/Feed/FeedPanel';
-import { Fragment, useState } from 'react';
 import dayjs from 'dayjs';
 import 'dayjs/locale/ko';
-import MeetingController from '@components/page/detail/MeetingController';
-import KakaoFloatingButton from '@components/FloatingButton/kakaoFloatingButton/KakaoFloatingButton';
+import CommonDetail from '@components/page/detail';
+import { GetMeetingResponse } from '@api/API_LEGACY/meeting';
 
 dayjs.locale('ko');
-
-const enum SelectedTab {
-  INFORMATION,
-  FEED,
-}
 
 const DetailPage = () => {
   const router = useRouter();
   const id = router.query.id as string;
   const { data: meetingData } = useQueryGetMeeting({ params: { id } });
-  const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
-  const { mutate: mutatePostApplication } = useMutationPostApplication({});
-  const { mutate: mutateDeleteApplication } = useMutationDeleteApplication({});
-  const [selectedIndex, setSelectedIndex] = useState(SelectedTab.INFORMATION);
 
-  if (!meetingData) {
-    return (
-      <>
-        <Loader />
-        <div style={{ position: 'fixed', bottom: '2%', right: '5%' }}>
-          <KakaoFloatingButton />
-        </div>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <SDetailPage>
-        <Carousel imageList={meetingData?.imageURL} />
-        <MeetingController
-          detailData={meetingData}
-          mutateMeetingDeletion={mutateDeleteMeeting}
-          mutateApplication={mutatePostApplication}
-          mutateApplicationDeletion={mutateDeleteApplication}
-        />
-        <Tab.Group selectedIndex={selectedIndex} onChange={index => setSelectedIndex(index)}>
-          <STabList>
-            <Tab as={Fragment}>
-              <STabButton isSelected={selectedIndex === SelectedTab.INFORMATION}>모임 안내</STabButton>
-            </Tab>
-            <Tab as={Fragment}>
-              <STabButton isSelected={selectedIndex === SelectedTab.FEED}>피드</STabButton>
-            </Tab>
-          </STabList>
-          <Tab.Panels>
-            <Tab.Panel>
-              <InformationPanel detailData={meetingData} />
-            </Tab.Panel>
-            <Tab.Panel>
-              <FeedPanel isMember={meetingData?.approved || meetingData?.host} />
-            </Tab.Panel>
-          </Tab.Panels>
-        </Tab.Group>
-      </SDetailPage>
-      <div style={{ position: 'fixed', bottom: '2%', right: '5%' }}>
-        <KakaoFloatingButton />
-      </div>
-    </>
-  );
+  return <CommonDetail detailData={meetingData as GetMeetingResponse} />;
 };
 
 export default DetailPage;
-
-const SDetailPage = styled('div', {
-  mb: '$374',
-
-  '@media (max-width: 768px)': {
-    mb: '$122',
-  },
-});
-
-const STabList = styled('div', {
-  display: 'flex',
-
-  '@media (max-width: 768px)': {
-    width: 'calc(100% + 40px)',
-    marginLeft: '-20px',
-  },
-
-  '@media (max-width: 414px)': {
-    width: 'calc(100% + 32px)',
-    marginLeft: '-16px',
-  },
-});
-
-const STabButton = styled('button', {
-  pb: '$24',
-  mr: '$32',
-  fontStyle: 'H1',
-  color: '$gray500',
-
-  '&:hover': {
-    color: '$gray10',
-  },
-
-  '@media (max-width: 768px)': {
-    fontStyle: 'T3',
-    padding: '$16 0',
-    mr: '$0',
-    flex: '1',
-    textAlign: 'center',
-  },
-
-  variants: {
-    isSelected: {
-      true: {
-        color: '$gray10',
-        borderBottom: `4px solid $gray10`,
-        '@media (max-width: 768px)': {
-          borderWidth: '2px',
-        },
-      },
-      false: {
-        color: '$gray500',
-        paddingBottom: '$28',
-        '@media (max-width: 768px)': {
-          paddingBottom: '$18',
-        },
-      },
-    },
-  },
-});

--- a/pages/list/index.tsx
+++ b/pages/list/index.tsx
@@ -1,15 +1,9 @@
-import { ampli } from '@/ampli';
-import { useQueryMyProfile } from '@api/API_LEGACY/user/hooks';
-import ConfirmModal from '@components/modal/ConfirmModal';
 import CardSkeleton from '@components/page/list/Card/Skeleton';
 import Filter from '@components/page/list/Filter';
 import GridLayout from '@components/page/list/Grid/Layout';
 import { MeetingListOfAll } from '@components/page/list/Grid/List';
 import { SSRSafeSuspense } from '@components/util/SSRSafeSuspense';
-import useModal from '@hooks/useModal';
-import { playgroundLink } from '@sopt-makers/playground-common';
 import type { NextPage } from 'next';
-import { useRouter } from 'next/router';
 import { styled } from 'stitches.config';
 import CrewTab from '@components/CrewTab';
 
@@ -17,19 +11,6 @@ import FloatingButton from '@components/FloatingButton';
 import GuideButton from '@components/GuideButton';
 
 const Home: NextPage = () => {
-  const router = useRouter();
-  const { data: me } = useQueryMyProfile();
-  const { isModalOpened, handleModalOpen, handleModalClose } = useModal();
-
-  const handleMakeMeeting = () => {
-    if (!me?.hasActivities) {
-      handleModalOpen();
-      return;
-    }
-    ampli.clickMakeGroup({ location: router.pathname });
-    router.push('/make');
-  };
-
   return (
     <>
       <div>
@@ -56,16 +37,6 @@ const Home: NextPage = () => {
           <MeetingListOfAll />
         </SSRSafeSuspense>
       </div>
-
-      <ConfirmModal
-        isModalOpened={isModalOpened}
-        message={`모임을 개설하려면\n프로필 작성이 필요해요`}
-        cancelButton="돌아가기"
-        confirmButton="작성하기"
-        handleModalClose={handleModalClose}
-        handleConfirm={() => (window.location.href = `${playgroundLink.memberUpload()}`)}
-      />
-
       <FloatingButton />
     </>
   );

--- a/src/components/groupBrowsing/Carousel/Carousel.tsx
+++ b/src/components/groupBrowsing/Carousel/Carousel.tsx
@@ -86,6 +86,12 @@ const SCarousel = styled('div', {
 
       left: '-27px',
     },
+    '@tablet': {
+      width: 'calc(100vw - 30px)',
+      minWidth: 'calc(100vw - 30px)',
+
+      left: '20px',
+    },
   },
 
   '.slick-list': {
@@ -110,11 +116,6 @@ const SCarousel = styled('div', {
         background: 'linear-gradient(270deg, #0F0F12 0%, rgba(15, 15, 18, 0.00) 100%)',
         pointerEvents: 'none',
       },
-    },
-    '@tablet': {
-      width: 'calc(100vw - 30px)',
-      minWidth: 'calc(100vw - 30px)',
-      left: '30px',
     },
   },
 

--- a/src/components/groupBrowsing/Carousel/Carousel.tsx
+++ b/src/components/groupBrowsing/Carousel/Carousel.tsx
@@ -57,15 +57,6 @@ const Carousel = ({ cardList }: CarouselProps) => {
     beforeChange: (current: number, next: number) => {
       setActiveSlide(next);
     },
-    // responsive: [
-    //   {
-    //     breakpoint: 1259,
-    //     settings: {
-    //       slidesToShow: 2.44,
-    //       slidesToScroll: 2,
-    //     },
-    //   },
-    // ],
   };
 
   return (
@@ -121,8 +112,9 @@ const SCarousel = styled('div', {
       },
     },
     '@tablet': {
-      width: '100vw',
-      minWidth: '100vw',
+      width: 'calc(100vw - 30px)',
+      minWidth: 'calc(100vw - 30px)',
+      left: '30px',
     },
   },
 

--- a/src/components/groupBrowsingSlider/groupBrowsingSlider.tsx
+++ b/src/components/groupBrowsingSlider/groupBrowsingSlider.tsx
@@ -9,13 +9,11 @@ interface CarouselProps {
 
 const GroupBrowsingSlider = ({ cardList }: CarouselProps) => {
   return (
-    <>
-      <SSlider>
-        {cardList.map(card => (
-          <MobileSizeCard key={card.id} {...card} />
-        ))}{' '}
-      </SSlider>
-    </>
+    <SSlider>
+      {cardList.map(card => (
+        <MobileSizeCard key={card.id} {...card} />
+      ))}{' '}
+    </SSlider>
   );
 };
 

--- a/src/components/groupBrowsingSlider/groupBrowsingSlider.tsx
+++ b/src/components/groupBrowsingSlider/groupBrowsingSlider.tsx
@@ -25,5 +25,4 @@ const SSlider = styled('div', {
   display: 'flex',
   gap: '$12',
   overflowX: 'auto',
-  paddingBottom: '40px',
 });

--- a/src/components/page/detail/index.tsx
+++ b/src/components/page/detail/index.tsx
@@ -1,0 +1,141 @@
+import { GetMeetingResponse } from '@api/API_LEGACY/meeting';
+import {
+  useMutationDeleteMeeting,
+  useMutationPostApplication,
+  useMutationDeleteApplication,
+} from '@api/API_LEGACY/meeting/hooks';
+import { GetFlashByIdResponse } from '@api/flash';
+import Loader from '@components/@common/loader/Loader';
+import KakaoFloatingButton from '@components/FloatingButton/kakaoFloatingButton/KakaoFloatingButton';
+import FeedPanel from '@components/page/detail/Feed/FeedPanel';
+import InformationPanel from '@components/page/detail/Information/InformationPanel';
+import MeetingController from '@components/page/detail/MeetingController';
+import { Tab } from '@headlessui/react';
+import { Fragment, useState } from 'react';
+import { styled } from 'stitches.config';
+import Carousel from '@components/page/detail/Carousel';
+
+type CommonDetailProps = {
+  detailData: GetMeetingResponse | GetFlashByIdResponse;
+};
+
+const enum SelectedTab {
+  INFORMATION,
+  FEED,
+}
+
+// /detail 과 /detail/flash 에서 공통적으로 사용하는 컴포넌트
+const CommonDetail = ({ detailData }: CommonDetailProps) => {
+  const { mutate: mutateDeleteMeeting } = useMutationDeleteMeeting({});
+  const { mutate: mutatePostApplication } = useMutationPostApplication({});
+  const { mutate: mutateDeleteApplication } = useMutationDeleteApplication({});
+  const [selectedIndex, setSelectedIndex] = useState(SelectedTab.INFORMATION);
+
+  if (!detailData) {
+    return (
+      <>
+        <Loader />
+        <div style={{ position: 'fixed', bottom: '2%', right: '5%' }}>
+          <KakaoFloatingButton />
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SDetailPage>
+        <Carousel imageList={detailData?.imageURL} />
+        <MeetingController
+          detailData={detailData}
+          mutateMeetingDeletion={mutateDeleteMeeting}
+          mutateApplication={mutatePostApplication}
+          mutateApplicationDeletion={mutateDeleteApplication}
+        />
+        <Tab.Group selectedIndex={selectedIndex} onChange={index => setSelectedIndex(index)}>
+          <STabList>
+            <Tab as={Fragment}>
+              <STabButton isSelected={selectedIndex === SelectedTab.INFORMATION}>모임 안내</STabButton>
+            </Tab>
+            <Tab as={Fragment}>
+              <STabButton isSelected={selectedIndex === SelectedTab.FEED}>피드</STabButton>
+            </Tab>
+          </STabList>
+          <Tab.Panels>
+            <Tab.Panel>
+              <InformationPanel detailData={detailData} />
+            </Tab.Panel>
+            <Tab.Panel>
+              <FeedPanel isMember={detailData?.approved || detailData?.host} />
+            </Tab.Panel>
+          </Tab.Panels>
+        </Tab.Group>
+      </SDetailPage>
+      <div style={{ position: 'fixed', bottom: '2%', right: '5%' }}>
+        <KakaoFloatingButton />
+      </div>
+    </>
+  );
+};
+
+export default CommonDetail;
+
+const SDetailPage = styled('div', {
+  mb: '$374',
+
+  '@media (max-width: 768px)': {
+    mb: '$122',
+  },
+});
+
+const STabList = styled('div', {
+  display: 'flex',
+
+  '@media (max-width: 768px)': {
+    width: 'calc(100% + 40px)',
+    marginLeft: '-20px',
+  },
+
+  '@media (max-width: 414px)': {
+    width: 'calc(100% + 32px)',
+    marginLeft: '-16px',
+  },
+});
+
+const STabButton = styled('button', {
+  pb: '$24',
+  mr: '$32',
+  fontStyle: 'H1',
+  color: '$gray500',
+
+  '&:hover': {
+    color: '$gray10',
+  },
+
+  '@media (max-width: 768px)': {
+    fontStyle: 'T3',
+    padding: '$16 0',
+    mr: '$0',
+    flex: '1',
+    textAlign: 'center',
+  },
+
+  variants: {
+    isSelected: {
+      true: {
+        color: '$gray10',
+        borderBottom: `4px solid $gray10`,
+        '@media (max-width: 768px)': {
+          borderWidth: '2px',
+        },
+      },
+      false: {
+        color: '$gray500',
+        paddingBottom: '$28',
+        '@media (max-width: 768px)': {
+          paddingBottom: '$18',
+        },
+      },
+    },
+  },
+});

--- a/src/components/page/list/Card/DesktopSizeCard/DesktopSizeFlashCard.tsx
+++ b/src/components/page/list/Card/DesktopSizeCard/DesktopSizeFlashCard.tsx
@@ -1,0 +1,24 @@
+import { MeetingListOfFilterResponse } from '@api/API_LEGACY/meeting';
+import { useFlashByIdQuery } from '@api/flash/hook';
+import DesktopSizeCard from '@components/page/list/Card/DesktopSizeCard';
+import { FlashInformation } from '@components/page/list/Card/DesktopSizeCard/constant';
+
+type DesktopSizeFlashCardProps = {
+  meetingData: MeetingListOfFilterResponse['meetings'][number];
+};
+const DesktopSizeFlashCard = ({ meetingData }: DesktopSizeFlashCardProps) => {
+  const { data: flashData } = useFlashByIdQuery({ meetingId: +meetingData.id });
+
+  const detailInfo = flashData ? FlashInformation(flashData) : undefined;
+
+  return (
+    <DesktopSizeCard
+      meetingData={meetingData}
+      isFlash
+      welcomeMessageTypes={flashData?.welcomeMessageTypes}
+      flashDetailInfo={detailInfo}
+    />
+  );
+};
+
+export default DesktopSizeFlashCard;

--- a/src/components/page/list/Card/DesktopSizeCard/index.tsx
+++ b/src/components/page/list/Card/DesktopSizeCard/index.tsx
@@ -6,35 +6,36 @@ import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
 import { getResizedImage } from '@utils/image';
 import { CategoryChip } from '@components/page/list/Card/DesktopSizeCard/CategoryChip';
 import RecruitmentStatusTag from '@components/Tag/RecruitmentStatusTag';
-import { useFlashByIdQuery } from '@api/flash/hook';
-import { FlashInformation, MeetingInformation } from '@components/page/list/Card/DesktopSizeCard/constant';
+import { MeetingInformation } from '@components/page/list/Card/DesktopSizeCard/constant';
 
 interface CardProps {
   meetingData: MeetingListOfFilterResponse['meetings'][number];
+  isFlash?: boolean;
+  welcomeMessageTypes?: string[];
+  flashDetailInfo?: {
+    label: string;
+    value: () => string;
+  }[];
 }
 
-function DesktopSizeCard({ meetingData }: CardProps) {
-  const { data: flashData } = useFlashByIdQuery({ meetingId: +meetingData.id });
-
-  const detailData = flashData ? flashData : meetingData;
-  const detailInfo = flashData ? FlashInformation(flashData) : MeetingInformation(meetingData);
+function DesktopSizeCard({ meetingData, isFlash = false, welcomeMessageTypes, flashDetailInfo }: CardProps) {
+  const detailInfo = isFlash && flashDetailInfo ? flashDetailInfo : MeetingInformation(meetingData);
 
   return (
     <div>
       <ImageWrapper>
-        <RecruitmentStatusTag status={detailData.status} style={{ position: 'absolute', top: '16px', left: '16px' }} />
+        <RecruitmentStatusTag status={meetingData.status} style={{ position: 'absolute', top: '16px', left: '16px' }} />
         <SThumbnailImage
           css={{
-            backgroundImage: `url(${detailData.imageURL[0]?.url})`,
+            backgroundImage: `url(${meetingData.imageURL[0]?.url})`,
           }}
         />
       </ImageWrapper>
 
       <STitleSection>
-        <CategoryChip
-          category={detailData.category as CategoryKoType}
-          welcomeMessage={flashData ? flashData.welcomeMessageTypes : []}
-        />
+        {isFlash && (
+          <CategoryChip category={meetingData.category as CategoryKoType} welcomeMessage={welcomeMessageTypes} />
+        )}
         <STitle>{meetingData.title}</STitle>
       </STitleSection>
 

--- a/src/components/page/list/Card/index.tsx
+++ b/src/components/page/list/Card/index.tsx
@@ -6,6 +6,7 @@ import { styled } from 'stitches.config';
 import { PART_OPTIONS, PART_VALUES, RECRUITMENT_STATUS } from '@constants/option';
 import { ampli } from '@/ampli';
 import { MeetingListOfFilterResponse } from '@api/API_LEGACY/meeting';
+import DesktopSizeFlashCard from '@components/page/list/Card/DesktopSizeCard/DesktopSizeFlashCard';
 
 interface CardProps {
   bottom?: ReactNode;
@@ -34,7 +35,7 @@ function Card({ bottom, meetingData, mobileType }: CardProps) {
     >
       <Link href={isFlash ? `/detail/flash?id=${meetingData.id}` : `/detail?id=${meetingData.id}`}>
         <DesktopOnly>
-          <DesktopSizeCard meetingData={meetingData} />
+          {isFlash ? <DesktopSizeFlashCard meetingData={meetingData} /> : <DesktopSizeCard meetingData={meetingData} />}
         </DesktopOnly>
         <MobileOnly>
           <MobileSizeCard meetingData={meetingData} isAllParts={isAllParts} mobileType={mobileType} />

--- a/src/components/page/list/Card/index.tsx
+++ b/src/components/page/list/Card/index.tsx
@@ -15,6 +15,7 @@ interface CardProps {
 
 function Card({ bottom, meetingData, mobileType }: CardProps) {
   const isAllParts = meetingData.joinableParts?.length === 6 || meetingData.joinableParts === null;
+  const isFlash = meetingData.category === '번쩍';
 
   return (
     <CardWrapper
@@ -31,7 +32,7 @@ function Card({ bottom, meetingData, mobileType }: CardProps) {
         });
       }}
     >
-      <Link href={`/detail?id=${meetingData.id}`}>
+      <Link href={isFlash ? `/detail/flash?id=${meetingData.id}` : `/detail?id=${meetingData.id}`}>
         <DesktopOnly>
           <DesktopSizeCard meetingData={meetingData} />
         </DesktopOnly>


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1043 

## 📋 작업 내용

- [x] flash 여부에 따라 링크 분기 처리
- [x] flash/meeting에 따라 detail 컴포넌트 분리
- [x] DesktopSizeCard 컴포넌트 flash용 추가

## 📌 PR Point

### 왜 이런 문제가 발생했냐

flashData와 meetingData가 종속성을 지녀서 발생한 문제였습니다.
컴포넌트 분리를 했어야 했는데, 번쩍 기능을 개발하던 당시 매우 촉박한 개발 기간(1주) 때문에 성능보다는 개발 속도를 내야했던 상황이었던 터라 임시방편으로 하나의 컴포넌트에서 Data만 갈아끼워주는 방식으로 설계하였습니다.
이럴 경우, flash (번쩍) 가 아님에도 아래의 사진과 같이 flash API를 호출하는 문제가 발생합니다. (network 탭에 오류로 찍히는 것들)

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c24ce52b-dfdc-470d-8272-00d3112cffd4" />

### detail 쪽 두번 호출되는 문제

해당 data가 번쩍인지 아닌지 확인할 방법이 `meetingData.category` 밖에 없습니다.
그래서 아래와 같이 detail 페이지 들어갈 때 `meetingData.category` 가 번쩍이면 `flash API` 를 호출하고, 번쩍이 아니면 `meetingData` 그대로 사용합니다

<img width="500" alt="image" src="https://github.com/user-attachments/assets/a7ae4330-a200-42c9-aba8-9ec19f0a0bf4" />

즉, `flash` 데이터임에도 `meetingData` 를 호출해야하고 / `meeting` 데이터임에도 불필요하게 `flashData` 가 호출되는 상황이 발생한 것입니다.
이에 대한 해결방안으로는 두가지를 생각했습니다.
1. category만 반환해주는 API 파기
2. url에 `flash` 넣기

[슬랙에서 기서와 논의한 결과](https://sopt-makers.slack.com/archives/C042SGKBFK7/p1738340470898789?thread_ts=1738048008.313079&cid=C042SGKBFK7) 2번 정책으로 결정되었고, 이에 따라 page 폴더에 `/detail/flash` 가 추가되었습니다.
그래서 list에서도 모임 클릭 시 flash 여부에 따라 flash면 `/detail/flash` 로 flash가 아닌 경우 `/detail` 로 이동하게 됩니다.

중복된 컴포넌트가 생기지 않도록 `components/page/detail/index.tsx` 에 flash와 flash가 아닌 페이지가 공통적으로 사용하는 컴포넌트를 분리하였습니다.

### list 쪽 두번 호출되는 문제

위와 동일한 이슈였고, flashData를 사용하고 있는 부분이 `DesktopSizeCard` 여서 flash의 경우 `DesktopSizeFlashCard` 를 사용하도록 해주었습니다.
`DesktopSizeFlashCard` 또한, 중복된 코드가 생기지 않도록 내부에서 `DesktopSizeCard` 를 사용합니다.

## 📸 스크린샷

네트워크 호출탭에 불필요한 API가 호출되지 않는 것을 중점으로 봐주시면 됩니다!

https://github.com/user-attachments/assets/93cbc243-99b1-485b-af4a-fff3fd8b3229


