### PR TITLE
이미지 리사이저 시범 적용 (병합 오류 해결)

### DIFF
--- a/src/components/page/home/HomeCardList/DesktopCard.tsx
+++ b/src/components/page/home/HomeCardList/DesktopCard.tsx
@@ -3,6 +3,7 @@ import { styled } from 'stitches.config';
 import UserIcon from '@assets/svg/user.svg?rect';
 import { CATEGORY_NAME, CategoryType, PART_NAME } from '@constants/option';
 import Link from 'next/link';
+import { getResizedImage } from '@utils/image';
 
 type DesktopCardProps = {
   id: number;
@@ -31,7 +32,7 @@ const DesktopCard = ({
   return (
     <Link href={`/detail?id=${id}`}>
       <SCardWrapper>
-        <SThumbnailImage src={imageURL} />
+        <SThumbnailImage src={getResizedImage(imageURL ?? '', 180)} />
         <SMetaWrapper style={{ paddingTop: '16px' }}>
           <Avatar src={ownerImage} alt={`${title} 모임장 프로필`} sx={{ width: '18px', height: '18px' }} />
           <SMetaStyle>

--- a/src/components/page/list/Card/DesktopSizeCard/index.tsx
+++ b/src/components/page/list/Card/DesktopSizeCard/index.tsx
@@ -27,7 +27,7 @@ function DesktopSizeCard({ meetingData, isFlash = false, welcomeMessageTypes, fl
         <RecruitmentStatusTag status={meetingData.status} style={{ position: 'absolute', top: '16px', left: '16px' }} />
         <SThumbnailImage
           css={{
-            backgroundImage: `url(${meetingData.imageURL[0]?.url})`,
+            backgroundImage: `url(${getResizedImage(detailData.imageURL[0]?.url ?? '', 380)})`,
           }}
         />
       </ImageWrapper>

--- a/src/components/page/list/Card/DesktopSizeCard/index.tsx
+++ b/src/components/page/list/Card/DesktopSizeCard/index.tsx
@@ -27,7 +27,7 @@ function DesktopSizeCard({ meetingData, isFlash = false, welcomeMessageTypes, fl
         <RecruitmentStatusTag status={meetingData.status} style={{ position: 'absolute', top: '16px', left: '16px' }} />
         <SThumbnailImage
           css={{
-            backgroundImage: `url(${getResizedImage(detailData.imageURL[0]?.url ?? '', 380)})`,
+            backgroundImage: `url(${getResizedImage(meetingData.imageURL[0]?.url ?? '', 380)})`,
           }}
         />
       </ImageWrapper>

--- a/src/components/page/list/Card/MobileSize/CardType.tsx
+++ b/src/components/page/list/Card/MobileSize/CardType.tsx
@@ -1,6 +1,7 @@
 import { RECRUITMENT_STATUS } from '@constants/option';
 import { styled } from 'stitches.config';
 import { MobileSizeCardProps } from '.';
+import { getResizedImage } from '@utils/image';
 
 function CardType({ meetingData }: Pick<MobileSizeCardProps, 'meetingData'>) {
   return (
@@ -9,7 +10,7 @@ function CardType({ meetingData }: Pick<MobileSizeCardProps, 'meetingData'>) {
         <SStatus recruitingStatus={meetingData.status}>{RECRUITMENT_STATUS[meetingData.status]}</SStatus>
         <SThumbnailImage
           css={{
-            backgroundImage: `url(${meetingData.imageURL[0]?.url})`,
+            backgroundImage: `url(${getResizedImage(meetingData.imageURL[0]?.url ?? '', 162)})`,
             backgroundSize: 'cover',
           }}
         />

--- a/src/components/page/list/Card/MobileSize/ListType.tsx
+++ b/src/components/page/list/Card/MobileSize/ListType.tsx
@@ -15,7 +15,7 @@ function ListType({ meetingData, isAllParts }: Omit<MobileSizeCardProps, 'mobile
           <RecruitmentStatusTag status={meetingData.status} style={{ position: 'absolute', top: '8px', left: '8px' }} />
           <SThumbnailImage
             css={{
-              backgroundImage: `url(${meetingData.imageURL[0]?.url})`,
+              backgroundImage: `url(${getResizedImage(meetingData.imageURL[0]?.url ?? '', 120)})`,
             }}
           />
         </ImageWrapper>

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,3 +1,3 @@
 export const getResizedImage = (src: string, width: number) => {
-  return `https://wsrv.nl/?url=${encodeURIComponent(src)}&w=${width}&output=webp`;
+  return `https://image-proxy-worker.makers.workers.dev?url=${encodeURIComponent(src)}&width=${width}`;
 };


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1051 

## 📋 작업 내용

오래된 브랜치여서, 자동 병합 도중에 오류가 있었던 듯 합니다!! 새로운 브랜치 생성해서 cherry pick 으로 필요한 커밋만 가지고 왔습니다!

이미지 리사이저를 시범 적용했어요.
앞으로 봐야 할 과제는, 서버비와 특정 이미지 형식에서 깨지는 이미지가 없는지 등의 요소들이에요
현재 3MB 정도 넘어가는 고용량 이미지는 라이브러리 한계 탓인지, 리사이징이 되지 않고 있어요. 이 경우에는 원본 이미지를 반환토록 하고 있습니다!
그냥 보면 무슨 차이지..? 라고 생각드실 수 있는데, 네트워크 쓰로틀링 걸어놓고 이전과 비교해보면 꽤 큰 차이가 납니다!! 드르륵 거리는 현상이 현저히 줄어들어요!
본 목적은 이미지 리사이징이었는데, 캐싱 기능도 함께 들어가져서 서버비 절약 효과도 부수적으로 있을 것이라 예상해요!
크루팀에서 먼저 적용한 뒤 서버비가 현저히 줄어드는 게 보이고 성능도 나쁘지 않다면, 다른 팀에 수출(?)하는 것도 고려해보겠습니다ㅎㅎ

## 📌 PR Point

- 무슨 이유로 어떻게 코드를 변경했는지
- 어떤 위험이나 우려가 발견되었는지
- 어떤 부분에 리뷰어가 집중해야 하는지
- 개발하면서 어떤 점이 궁금했는지

## 📸 스크린샷
