### PR TITLE
모임 키워드화 QA 반영

### DIFF
--- a/pages/edit/flash/index.tsx
+++ b/pages/edit/flash/index.tsx
@@ -35,7 +35,7 @@ const FlashEditPage = () => {
     resolver: zodResolver(flashSchema),
   });
 
-  const { isValid, errors } = formMethods.formState;
+  const { isValid, errors, isDirty } = formMethods.formState;
 
   const onSubmit: SubmitHandler<FlashFormType> = async formData => {
     try {
@@ -119,7 +119,7 @@ const FlashEditPage = () => {
               handleChangeImage={handleChangeImage}
               handleDeleteImage={handleDeleteImage}
               onSubmit={formMethods.handleSubmit(onSubmit)}
-              disabled={isSubmitting || !isValid}
+              disabled={isSubmitting || !isValid || Object.keys(errors).length > 0 || !isDirty}
               placeType={formData.flashPlaceType as '협의 후 결정' | '오프라인' | '온라인'}
               timeType={formData.flashTimingType as '당일' | '예정 기간 (협의 후 결정)'}
             />

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -1,20 +1,19 @@
+import { updateMeeting } from '@api/API_LEGACY/meeting';
+import { useQueryGetMeeting } from '@api/API_LEGACY/meeting/hooks';
+import CheckIcon from '@assets/svg/check.svg';
+import Loader from '@components/@common/loader/Loader';
 import Presentation from '@components/form/Presentation';
 import TableOfContents from '@components/form/TableOfContents';
+import { parts } from '@data/options';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { FormType, schema } from '@type/form';
+import { formatCalendarDate } from '@utils/dayjs';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
-import { updateMeeting } from '@api/API_LEGACY/meeting';
-import { FormType, schema } from '@type/form';
 import { styled } from 'stitches.config';
-import dayjs from 'dayjs';
-import Loader from '@components/@common/loader/Loader';
-import CheckIcon from '@assets/svg/check.svg';
-import dynamic from 'next/dynamic';
-import { parts } from '@data/options';
-import { useQueryGetMeeting } from '@api/API_LEGACY/meeting/hooks';
-import { formatCalendarDate } from '@utils/dayjs';
 const DevTool = dynamic(() => import('@hookform/devtools').then(module => module.DevTool), {
   ssr: false,
 });
@@ -41,6 +40,7 @@ const EditPage = () => {
       },
     },
   });
+  const { isValid, errors, isDirty } = formMethods.formState;
 
   const onSubmit: SubmitHandler<FormType> = async formData => {
     try {
@@ -125,7 +125,7 @@ const EditPage = () => {
               handleChangeImage={handleChangeImage}
               handleDeleteImage={handleDeleteImage}
               onSubmit={formMethods.handleSubmit(onSubmit)}
-              disabled={isSubmitting}
+              disabled={isSubmitting || !isValid || Object.keys(errors).length > 0 || !isDirty}
             />
           </SFormWrapper>
         </SFormContainer>

--- a/pages/make/flash/index.tsx
+++ b/pages/make/flash/index.tsx
@@ -22,7 +22,7 @@ const Flash = () => {
     mode: 'onChange',
     resolver: zodResolver(flashSchema),
   });
-  const { isValid, errors } = formMethods.formState;
+  const { isValid, errors, isDirty } = formMethods.formState;
   const { mutateAsync: mutateCreateFlash, isLoading: isSubmitting } = useMutation({
     mutationFn: (formData: FlashFormType) => createFlash(formData),
     onError: () => {
@@ -69,7 +69,7 @@ const Flash = () => {
             handleChangeImage={handleChangeImage}
             handleDeleteImage={handleDeleteImage}
             onSubmit={formMethods.handleSubmit(onSubmit)}
-            disabled={isSubmitting || !isValid}
+            disabled={isSubmitting || !isValid || Object.keys(errors).length > 0 || !isDirty}
           />
         </SFormContainer>
       </SContainer>

--- a/pages/make/index.tsx
+++ b/pages/make/index.tsx
@@ -29,7 +29,7 @@ const MakePage = () => {
       },
     },
   });
-  const { isValid } = formMethods.formState;
+  const { isValid, errors, isDirty } = formMethods.formState;
   const { mutateAsync: mutateCreateMeeting, isLoading: isSubmitting } = useMutation({
     mutationFn: (formData: FormType) => createMeeting(formData),
     onError: () => {
@@ -72,7 +72,7 @@ const MakePage = () => {
             handleChangeImage={handleChangeImage}
             handleDeleteImage={handleDeleteImage}
             onSubmit={formMethods.handleSubmit(onSubmit)}
-            disabled={isSubmitting || !isValid}
+            disabled={isSubmitting || !isValid || Object.keys(errors).length > 0 || !isDirty}
           />
         </SFormContainer>
         <TableOfContents label="모임 개설" />

--- a/src/components/form/Presentation/KeywordField/index.tsx
+++ b/src/components/form/Presentation/KeywordField/index.tsx
@@ -4,11 +4,27 @@ import Label from '@components/form/Label';
 import { Option } from '@components/form/Select/OptionItem';
 import { keywordOptions } from '@data/options';
 import { Chip } from '@sopt-makers/ui';
+import { useCallback } from 'react';
 import { styled } from 'stitches.config';
 
 const MAX_KEYWORD_COUNT = 2;
 
 const KeywordField = () => {
+  const handleClick = useCallback((option: Option, value: string[], onChange: (value: string[]) => void) => {
+    if (!option.value) return;
+
+    let updatedKeywords = [...value];
+    if (updatedKeywords.includes(option.value)) {
+      updatedKeywords = updatedKeywords.filter(keyword => keyword !== option.value);
+    } else {
+      updatedKeywords.push(option.value);
+    }
+
+    if (updatedKeywords.length > MAX_KEYWORD_COUNT) return;
+
+    onChange(updatedKeywords);
+  }, []);
+
   return (
     <div>
       <Label required={true}>모임 키워드</Label>
@@ -17,19 +33,6 @@ const KeywordField = () => {
         name="meetingKeywordTypes"
         defaultValue={[]}
         render={({ field: { value, onChange } }) => {
-          const handleClick = (option: Option) => {
-            let updatedKeywords = [...value];
-            if (updatedKeywords.includes(option.value)) {
-              updatedKeywords = updatedKeywords.filter(keyword => keyword !== option.value);
-            } else {
-              updatedKeywords.push(option.value);
-            }
-
-            if (updatedKeywords.length > MAX_KEYWORD_COUNT) return;
-
-            onChange(updatedKeywords);
-          };
-
           return (
             <SChipContainer>
               {keywordOptions.map(option => {
@@ -39,7 +42,7 @@ const KeywordField = () => {
                     disabled={value.length >= MAX_KEYWORD_COUNT && !isSelected}
                     key={option.value}
                     active={isSelected}
-                    onClick={() => handleClick(option)}
+                    onClick={() => handleClick(option, value, onChange)}
                   >
                     {option.label}
                   </Chip>

--- a/src/components/form/Presentation/KeywordField/index.tsx
+++ b/src/components/form/Presentation/KeywordField/index.tsx
@@ -6,11 +6,13 @@ import { keywordOptions } from '@data/options';
 import { Chip } from '@sopt-makers/ui';
 import { styled } from 'stitches.config';
 
+const MAX_KEYWORD_COUNT = 2;
+
 const KeywordField = () => {
   return (
     <div>
       <Label required={true}>모임 키워드</Label>
-      <HelpMessage>최대 2개까지 선택할 수 있어요</HelpMessage>
+      <HelpMessage>최대 {MAX_KEYWORD_COUNT}개까지 선택할 수 있어요</HelpMessage>
       <FormController
         name="meetingKeywordTypes"
         defaultValue={[]}
@@ -23,18 +25,26 @@ const KeywordField = () => {
               updatedKeywords.push(option.value);
             }
 
-            if (updatedKeywords.length > 2) return;
+            if (updatedKeywords.length > MAX_KEYWORD_COUNT) return;
 
             onChange(updatedKeywords);
           };
 
           return (
             <SChipContainer>
-              {keywordOptions.map(option => (
-                <Chip key={option.value} active={value.includes(option.value)} onClick={() => handleClick(option)}>
-                  {option.label}
-                </Chip>
-              ))}
+              {keywordOptions.map(option => {
+                const isSelected = value.includes(option.value);
+                return (
+                  <Chip
+                    disabled={value.length >= MAX_KEYWORD_COUNT && !isSelected}
+                    key={option.value}
+                    active={isSelected}
+                    onClick={() => handleClick(option)}
+                  >
+                    {option.label}
+                  </Chip>
+                );
+              })}
             </SChipContainer>
           );
         }}

--- a/src/components/form/Presentation/KeywordField/index.tsx
+++ b/src/components/form/Presentation/KeywordField/index.tsx
@@ -33,30 +33,26 @@ const KeywordField = () => {
       <FormController
         name="meetingKeywordTypes"
         defaultValue={[]}
-        render={({ field: { value, onChange }, fieldState: { error: keywordError } }) => {
-          const m = keywordError?.message;
-
-          return (
-            <>
-              <SChipContainer>
-                {keywordOptions.map(option => {
-                  const isSelected = value.includes(option.value);
-                  return (
-                    <Chip
-                      disabled={value.length >= MAX_KEYWORD_COUNT && !isSelected}
-                      key={option.value}
-                      active={isSelected}
-                      onClick={() => handleClick(option, value, onChange)}
-                    >
-                      {option.label}
-                    </Chip>
-                  );
-                })}
-              </SChipContainer>
-              <ErrorMessage style={{ marginTop: '12px' }}>{keywordError?.message}</ErrorMessage>
-            </>
-          );
-        }}
+        render={({ field: { value, onChange }, fieldState: { error: keywordError } }) => (
+          <>
+            <SChipContainer>
+              {keywordOptions.map(option => {
+                const isSelected = value.includes(option.value);
+                return (
+                  <Chip
+                    disabled={value.length >= MAX_KEYWORD_COUNT && !isSelected}
+                    key={option.value}
+                    active={isSelected}
+                    onClick={() => handleClick(option, value, onChange)}
+                  >
+                    {option.label}
+                  </Chip>
+                );
+              })}
+            </SChipContainer>
+            {keywordError && <ErrorMessage style={{ marginTop: '12px' }}>{keywordError.message}</ErrorMessage>}
+          </>
+        )}
       ></FormController>
     </div>
   );

--- a/src/components/form/Presentation/KeywordField/index.tsx
+++ b/src/components/form/Presentation/KeywordField/index.tsx
@@ -1,3 +1,4 @@
+import ErrorMessage from '@components/form/ErrorMessage';
 import FormController from '@components/form/FormController';
 import HelpMessage from '@components/form/HelpMessage';
 import Label from '@components/form/Label';
@@ -32,23 +33,28 @@ const KeywordField = () => {
       <FormController
         name="meetingKeywordTypes"
         defaultValue={[]}
-        render={({ field: { value, onChange } }) => {
+        render={({ field: { value, onChange }, fieldState: { error: keywordError } }) => {
+          const m = keywordError?.message;
+
           return (
-            <SChipContainer>
-              {keywordOptions.map(option => {
-                const isSelected = value.includes(option.value);
-                return (
-                  <Chip
-                    disabled={value.length >= MAX_KEYWORD_COUNT && !isSelected}
-                    key={option.value}
-                    active={isSelected}
-                    onClick={() => handleClick(option, value, onChange)}
-                  >
-                    {option.label}
-                  </Chip>
-                );
-              })}
-            </SChipContainer>
+            <>
+              <SChipContainer>
+                {keywordOptions.map(option => {
+                  const isSelected = value.includes(option.value);
+                  return (
+                    <Chip
+                      disabled={value.length >= MAX_KEYWORD_COUNT && !isSelected}
+                      key={option.value}
+                      active={isSelected}
+                      onClick={() => handleClick(option, value, onChange)}
+                    >
+                      {option.label}
+                    </Chip>
+                  );
+                })}
+              </SChipContainer>
+              <ErrorMessage style={{ marginTop: '12px' }}>{keywordError?.message}</ErrorMessage>
+            </>
           );
         }}
       ></FormController>

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -279,7 +279,10 @@ export const flashSchema = z.object({
     }),
   files: z.array(z.string()),
   welcomeMessageTypes: z.array(z.string()).max(3, { message: '최대 3개까지 선택할 수 있어요' }).optional().nullable(),
-  meetingKeywordTypes: z.array(z.string()).max(2, { message: '최대 2개까지 선택할 수 있어요' }),
+  meetingKeywordTypes: z
+    .array(z.string())
+    .max(2, { message: '최대 2개까지 선택할 수 있어요' })
+    .min(1, { message: '키워드를 선택해주세요' }),
 });
 
 export type FlashFormType = z.infer<typeof flashSchema>;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -32,7 +32,10 @@ export const schema = z.object({
       invalid_type_error: '카테고리를 선택해주세요.',
     }),
   }),
-  meetingKeywordTypes: z.array(z.string()).max(2, { message: '최대 2개까지 선택할 수 있어요' }),
+  meetingKeywordTypes: z
+    .array(z.string())
+    .max(2, { message: '최대 2개까지 선택할 수 있어요' })
+    .min(1, { message: '키워드를 선택해주세요' }),
   welcomeMessageTypes: z.array(z.string()).max(3, { message: '최대 3개까지 선택할 수 있어요' }).optional().nullable(),
   files: z
     .array(z.string(), { required_error: '이미지를 추가해주세요.' })


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1110 

## 📋 작업 내용

- [x] keyword MAX_COUNT 초과 시 disabled 적용
- [x] click 이벤트 핸들러 render 밖으로 분리
- [x] 키워드 선택하지 않았을 때 에러 메세지 출력
- [x] submitButton disabled에 dirty, errors 고려

## 📌 PR Point

- keyword MAX_COUNT 초과 시 disabled 적용
  - category `Chip` 에 `disabled` 조건을 추가시켰습니다!
  - `MAX_KEYWORD_COUNT`도 상수처리해주었습니다!

- click 이벤트 핸들러 render 밖으로 분리
  - 지난 번에 `welcomeMessageTagField` 에서 받았던 코드리뷰인데
  - 비슷한 구조의 컴포넌트라 동일하게 리뷰 적용했습니다!

- 키워드 선택하지 않았을 때 에러 메세지 출력
  - `schema` 에서 `min` 조건 추가하여
  - `fieldState: { error }` 를 이용했습니다!
  - 조건 추가할 때 `{message}` 속성도 같이 넣어주면, error 발생시 `error.message` 를 가져올 수 있습니다

- SubmitButton diabled 조건 추가
  - 기존에는 `isValid` 만 고려해서 disabled 처리해주었더라구요!
  - `errors` 랑 `dirty` 도 disabled 조건에 필요한 요소들이어서 추가해주었습니다!

## 📸 스크린샷

https://github.com/user-attachments/assets/55a00a10-7e21-4495-aebf-368a37e1e34e


