### PR TITLE
[Feat] 툴팁 모바일 반응형 디자인 수정 요청사항 적용

### DIFF
--- a/src/components/CrewTab/index.tsx
+++ b/src/components/CrewTab/index.tsx
@@ -17,7 +17,7 @@ const CrewTab = ({ children }: { children?: ReactNode }) => {
   const lastSegment = (path.split('/').at(-1) || 'group') as keyof typeof tabText;
 
   return (
-    <Flex align="start" justify="between">
+    <Flex align="center" justify="between">
       <TabList text={tabText[lastSegment]} size="big">
         <Link href="/" onClick={() => ampli.clickNavbarGroup({ menu: '피드' })}>
           <TabList.Item text="feedAll">홈</TabList.Item>

--- a/src/components/KeywordsSettingButton/index.tsx
+++ b/src/components/KeywordsSettingButton/index.tsx
@@ -1,28 +1,22 @@
-import { styled } from 'stitches.config';
-import { useEffect, useState } from 'react';
-import { Tooltip } from '@components/Tooltip/Tooltip';
-
-import { Tag } from '@sopt-makers/ui';
-import { useDisplay } from '@hooks/useDisplay';
-import { IconBell, IconChevronRight } from '@sopt-makers/icons';
+import { KeywordSettingOptionType } from '@api/user';
+import { useMutationInterestedKeywords, useQueryGetInterestedKeywords } from '@api/user/hooks';
 import AlarmSettingBottomSheet from '@components/page/list/Alarm/BottomSheet/AlarmSettingBottomSheet';
 import AlarmSettingModal from '@components/page/list/Alarm/Modal/AlarmSettingModal';
-import { useMutationInterestedKeywords, useQueryGetInterestedKeywords } from '@api/user/hooks';
-import { fontsObject } from '@sopt-makers/fonts';
-import { KeywordSettingOptionType } from '@api/user';
+import { Tooltip } from '@components/Tooltip/Tooltip';
+import { useDisplay } from '@hooks/useDisplay';
+import { useEffect, useState } from 'react';
+import { TooltipContent } from '@components/page/list/AlarmSetting/TooltipContent/TooltipContent';
+import SettingButton from '@components/page/list/AlarmSetting/SettingButton/SettingButton';
 
 const KeywordsSettingButton = () => {
   const [isTooltipOpen, setIsTooltipOpen] = useState(true);
-  const { isDesktop, isTablet, isMobile } = useDisplay();
+  const { isDesktop } = useDisplay();
 
   const { mutate: mutateUserInterested } = useMutationInterestedKeywords();
   const { data: userInterested } = useQueryGetInterestedKeywords();
 
   const [selectedAlarm, setSelectedAlarm] = useState<KeywordSettingOptionType[]>(() => userInterested?.keywords ?? []);
   const [isSettingOpen, setIsSettingOpen] = useState(false);
-
-  const isModalOpened = isSettingOpen && isDesktop;
-  const isBottomSheetOpen = isSettingOpen && !isDesktop;
 
   const handleKeywordClick = (value: KeywordSettingOptionType) => {
     setSelectedAlarm(prev => {
@@ -37,10 +31,6 @@ const KeywordsSettingButton = () => {
     mutateUserInterested([]);
   };
 
-  const handleSettingClick = () => {
-    setIsSettingOpen(true);
-  };
-
   useEffect(() => {
     // 데이터가 로드 된 시점에 "이미 선택된 키워드" 세팅
     if (userInterested?.keywords) {
@@ -52,102 +42,25 @@ const KeywordsSettingButton = () => {
     <>
       <Tooltip.Root isTooltipOpen={isTooltipOpen} onTooltipToggle={setIsTooltipOpen}>
         <Tooltip.Trigger>
-          {isMobile ? (
-            <SSettingButton onClick={handleSettingClick}>
-              <SIconBell />
-              키워드 알림 설정
-            </SSettingButton>
-          ) : isTablet ? (
-            <SSettingButton onClick={handleSettingClick}>
-              키워드 알림 설정
-              <SIconBell />
-            </SSettingButton>
-          ) : (
-            <SSettingButton onClick={handleSettingClick}>
-              <SIconBell />
-              키워드 알림 설정
-              {selectedAlarm.length > 0 && <SSelectedAlarm>{selectedAlarm.join(', ')}</SSelectedAlarm>}
-              <SIconChevronRight />
-            </SSettingButton>
-          )}
+          <SettingButton onClick={() => setIsSettingOpen(true)} selectedKeywords={selectedAlarm} />
         </Tooltip.Trigger>
-        {isMobile ? (
-          <Tooltip.Content>
-            관심 키워드 설정하고 <br />
-            신규 모임 개설 알림을 받아보세요
-          </Tooltip.Content>
-        ) : (
-          <Tooltip.Content
-            TooltipClose={<Tooltip.Close />}
-            title={'키워드 알림'}
-            titleRightIcon={
-              <Tag variant="primary" size="sm">
-                NEW
-              </Tag>
-            }
-          >
-            관심 키워드 설정하고 <br />
-            신규 모임 개설 알림을 받아보세요
-          </Tooltip.Content>
-        )}
+        <TooltipContent />
       </Tooltip.Root>
-      {isModalOpened && (
-        <AlarmSettingModal
-          isOpen={isSettingOpen && isDesktop}
-          close={() => setIsSettingOpen(false)}
-          selectedAlarm={selectedAlarm}
-          onKeywordClick={handleKeywordClick}
-          onReset={handleReset}
-        />
-      )}
-      {isBottomSheetOpen && (
-        <AlarmSettingBottomSheet
-          isOpen={isBottomSheetOpen}
-          close={() => setIsSettingOpen(false)}
-          selectedAlarm={selectedAlarm}
-          onKeywordClick={handleKeywordClick}
-        />
-      )}
+      <AlarmSettingModal
+        isOpen={isSettingOpen && isDesktop}
+        close={() => setIsSettingOpen(false)}
+        selectedAlarm={selectedAlarm}
+        onKeywordClick={handleKeywordClick}
+        onReset={handleReset}
+      />
+      <AlarmSettingBottomSheet
+        isOpen={isSettingOpen && !isDesktop}
+        close={() => setIsSettingOpen(false)}
+        selectedAlarm={selectedAlarm}
+        onKeywordClick={handleKeywordClick}
+      />
     </>
   );
 };
 
 export default KeywordsSettingButton;
-
-const SIconBell = styled(IconBell, {
-  width: '20px',
-  height: '20px',
-  '@mobile': {
-    width: '16px',
-    height: '16px',
-  },
-});
-
-const SIconChevronRight = styled(IconChevronRight, {
-  width: '20px',
-  height: '20px',
-});
-
-const SSelectedAlarm = styled('span', {
-  ...fontsObject.BODY_3_14_M,
-  color: '$blue400',
-});
-
-const SSettingButton = styled('a', {
-  flexType: 'verticalCenter',
-  gap: '$8',
-  color: '$gray10',
-  fontAg: '18_semibold_100',
-
-  '@tablet': {
-    padding: '0',
-    fontAg: '14_semibold_100',
-  },
-
-  path: {
-    stroke: '$gray10',
-  },
-  '@media (max-width: 320px)': {
-    display: 'none',
-  },
-});

--- a/src/components/KeywordsSettingButton/index.tsx
+++ b/src/components/KeywordsSettingButton/index.tsx
@@ -42,11 +42,11 @@ const KeywordsSettingButton = () => {
   };
 
   useEffect(() => {
-    // 모달이 열릴 시점, 그리고 데이터가 로드 된 시점에 "이미 선택된 키워드" 세팅
-    if (isSettingOpen && userInterested?.keywords) {
+    // 데이터가 로드 된 시점에 "이미 선택된 키워드" 세팅
+    if (userInterested?.keywords) {
       setSelectedAlarm(userInterested.keywords);
     }
-  }, [isSettingOpen, userInterested]);
+  }, [userInterested]);
 
   return (
     <>

--- a/src/components/KeywordsSettingButton/index.tsx
+++ b/src/components/KeywordsSettingButton/index.tsx
@@ -13,7 +13,7 @@ import { KeywordSettingOptionType } from '@api/user';
 
 const KeywordsSettingButton = () => {
   const [isTooltipOpen, setIsTooltipOpen] = useState(true);
-  const { isDesktop, isTablet } = useDisplay();
+  const { isDesktop, isTablet, isMobile } = useDisplay();
 
   const { mutate: mutateUserInterested } = useMutationInterestedKeywords();
   const { data: userInterested } = useQueryGetInterestedKeywords();
@@ -52,7 +52,12 @@ const KeywordsSettingButton = () => {
     <>
       <Tooltip.Root isTooltipOpen={isTooltipOpen} onTooltipToggle={setIsTooltipOpen}>
         <Tooltip.Trigger>
-          {isTablet ? (
+          {isMobile ? (
+            <SSettingButton onClick={handleSettingClick}>
+              <SIconBell />
+              키워드 알림 설정
+            </SSettingButton>
+          ) : isTablet ? (
             <SSettingButton onClick={handleSettingClick}>
               키워드 알림 설정
               <SIconBell />
@@ -66,18 +71,25 @@ const KeywordsSettingButton = () => {
             </SSettingButton>
           )}
         </Tooltip.Trigger>
-        <Tooltip.Content
-          TooltipClose={<Tooltip.Close />}
-          title={'키워드 알림'}
-          titleRightIcon={
-            <Tag variant="primary" size="sm">
-              NEW
-            </Tag>
-          }
-        >
-          관심 키워드 설정하고 <br />
-          신규 모임 개설 알림을 받아보세요
-        </Tooltip.Content>
+        {isMobile ? (
+          <Tooltip.Content>
+            관심 키워드 설정하고 <br />
+            신규 모임 개설 알림을 받아보세요
+          </Tooltip.Content>
+        ) : (
+          <Tooltip.Content
+            TooltipClose={<Tooltip.Close />}
+            title={'키워드 알림'}
+            titleRightIcon={
+              <Tag variant="primary" size="sm">
+                NEW
+              </Tag>
+            }
+          >
+            관심 키워드 설정하고 <br />
+            신규 모임 개설 알림을 받아보세요
+          </Tooltip.Content>
+        )}
       </Tooltip.Root>
       {isModalOpened && (
         <AlarmSettingModal
@@ -105,6 +117,10 @@ export default KeywordsSettingButton;
 const SIconBell = styled(IconBell, {
   width: '20px',
   height: '20px',
+  '@mobile': {
+    width: '16px',
+    height: '16px',
+  },
 });
 
 const SIconChevronRight = styled(IconChevronRight, {
@@ -121,7 +137,6 @@ const SSettingButton = styled('a', {
   flexType: 'verticalCenter',
   gap: '$8',
   color: '$gray10',
-  padding: '$8 $6 0 0',
   fontAg: '18_semibold_100',
 
   '@tablet': {
@@ -132,7 +147,7 @@ const SSettingButton = styled('a', {
   path: {
     stroke: '$gray10',
   },
-  '@media (max-width: 359px)': {
+  '@media (max-width: 320px)': {
     display: 'none',
   },
 });

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -40,7 +40,7 @@ export const Tooltip = {
 const TooltipWrap = styled('div', {
   position: 'relative',
   zIndex: 1,
-  '@media (max-width: 359px)': {
+  '@media (max-width: 320px)': {
     display: 'none',
   },
 });

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -23,10 +23,12 @@ export const TooltipContent = ({ children, title, titleRightIcon, TooltipClose }
       </SPointDiv>
       <STextDiv>
         <STooltipHeader>
-          <STitleDiv>
-            {title}
-            {titleRightIcon && titleRightIcon}
-          </STitleDiv>
+          {(title || titleRightIcon) && (
+            <STitleDiv>
+              {title}
+              {titleRightIcon && titleRightIcon}
+            </STitleDiv>
+          )}
           {TooltipClose && TooltipClose}
         </STooltipHeader>
         {children}
@@ -46,6 +48,7 @@ const STitleDiv = styled('div', {
   flexDirection: 'row',
   alignItems: 'center',
   gap: '4px',
+  marginBottom: '8px',
 
   color: '$gray30',
   ...fontsObject.TITLE_7_14_SB,
@@ -77,7 +80,6 @@ const SPointDiv = styled('div', {
 const STextDiv = styled('div', {
   display: 'flex',
   flexDirection: 'column',
-  gap: '8px',
 
   width: '255px',
   padding: '16px',

--- a/src/components/Tooltip/TooltipContent.tsx
+++ b/src/components/Tooltip/TooltipContent.tsx
@@ -47,8 +47,8 @@ const STitleDiv = styled('div', {
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  gap: '4px',
-  marginBottom: '8px',
+  gap: '$4',
+  marginBottom: '$8',
 
   color: '$gray30',
   ...fontsObject.TITLE_7_14_SB,
@@ -65,8 +65,12 @@ const STooltipDiv = styled('div', {
   flexDirection: 'column',
   alignItems: 'flex-end',
 
-  width: '252px',
-  height: '162px',
+  maxWidth: '$252',
+  width: '100%',
+  height: '$162',
+  '@mobile': {
+    top: '$25',
+  },
 });
 
 const SPointDiv = styled('div', {
@@ -74,7 +78,10 @@ const SPointDiv = styled('div', {
   flexDirection: 'column',
   alignItems: 'flex-start',
 
-  padding: '1px 16px 0 0',
+  padding: '$1 $16 0 0',
+  '@mobile': {
+    padding: '$1 $100 0 0',
+  },
 });
 
 const STextDiv = styled('div', {
@@ -82,11 +89,14 @@ const STextDiv = styled('div', {
   flexDirection: 'column',
 
   width: '255px',
-  padding: '16px',
+  padding: '$16',
 
-  borderRadius: '12px',
+  borderRadius: '$12',
   backgroundColor: '$gray600',
   color: '$gray50',
 
   ...fontsObject.BODY_4_13_M,
+  '@mobile': {
+    width: '204px',
+  },
 });

--- a/src/components/page/list/AlarmSetting/SettingButton/SettingButton.css.ts
+++ b/src/components/page/list/AlarmSetting/SettingButton/SettingButton.css.ts
@@ -1,0 +1,42 @@
+import { styled } from '@stitches/react';
+import { IconBell, IconChevronRight } from '@sopt-makers/icons';
+import { fontsObject } from '@sopt-makers/fonts';
+
+export const SIconBell = styled(IconBell, {
+  width: '20px',
+  height: '20px',
+  '@mobile': {
+    width: '16px',
+    height: '16px',
+  },
+});
+
+export const SIconChevronRight = styled(IconChevronRight, {
+  width: '20px',
+  height: '20px',
+});
+
+export const SSelectedAlarm = styled('span', {
+  ...fontsObject.BODY_3_14_M,
+  color: '$blue400',
+});
+
+export const SSettingButton = styled('button', {
+  display: 'flex',
+  flexType: 'verticalCenter',
+  gap: '$8',
+  color: '$gray10',
+  fontAg: '18_semibold_100',
+
+  '@tablet': {
+    padding: '0',
+    fontAg: '14_semibold_100',
+  },
+
+  path: {
+    stroke: '$gray10',
+  },
+  '@media (max-width: 320px)': {
+    display: 'none',
+  },
+});

--- a/src/components/page/list/AlarmSetting/SettingButton/SettingButton.tsx
+++ b/src/components/page/list/AlarmSetting/SettingButton/SettingButton.tsx
@@ -1,0 +1,45 @@
+import { useDisplay } from '@hooks/useDisplay';
+import {
+  SIconBell,
+  SIconChevronRight,
+  SSelectedAlarm,
+  SSettingButton,
+} from '@components/page/list/AlarmSetting/SettingButton/SettingButton.css';
+
+interface SettingButtonProps {
+  onClick: () => void;
+  selectedKeywords: string[];
+}
+
+const SettingButton = ({ onClick, selectedKeywords }: SettingButtonProps) => {
+  const { isMobile, isTablet } = useDisplay();
+
+  if (isMobile) {
+    return (
+      <SSettingButton onClick={onClick}>
+        <SIconBell />
+        키워드 알림 설정
+      </SSettingButton>
+    );
+  }
+
+  if (isTablet) {
+    return (
+      <SSettingButton onClick={onClick}>
+        키워드 알림 설정
+        <SIconBell />
+      </SSettingButton>
+    );
+  }
+
+  return (
+    <SSettingButton onClick={onClick}>
+      <SIconBell />
+      키워드 알림 설정
+      {selectedKeywords.length > 0 && <SSelectedAlarm>{selectedKeywords.join(', ')}</SSelectedAlarm>}
+      <SIconChevronRight />
+    </SSettingButton>
+  );
+};
+
+export default SettingButton;

--- a/src/components/page/list/AlarmSetting/TooltipContent/TooltipContent.tsx
+++ b/src/components/page/list/AlarmSetting/TooltipContent/TooltipContent.tsx
@@ -1,0 +1,31 @@
+import { useDisplay } from '@hooks/useDisplay';
+import { Tooltip } from '@components/Tooltip/Tooltip';
+import { Tag } from '@sopt-makers/ui';
+
+export const TooltipContent = () => {
+  const { isMobile } = useDisplay();
+
+  if (isMobile) {
+    return (
+      <Tooltip.Content>
+        관심 키워드 설정하고 <br />
+        신규 모임 개설 알림을 받아보세요
+      </Tooltip.Content>
+    );
+  }
+
+  return (
+    <Tooltip.Content
+      TooltipClose={<Tooltip.Close />}
+      title={'키워드 알림'}
+      titleRightIcon={
+        <Tag variant="primary" size="sm">
+          NEW
+        </Tag>
+      }
+    >
+      관심 키워드 설정하고 <br />
+      신규 모임 개설 알림을 받아보세요
+    </Tooltip.Content>
+  );
+};


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1150

## 📋 작업 내용

- [x] 320 이하 -> 툴팁 제거
- [x] 모바일 에서는 벨 아이콘과 title 위치 변경
- [x] 모바일 툴팁 디자인(사이즈 및 뾰족 위치) 변경 요청사항 적용
- [x] 모달 열릴 때 말고 데이터가 로드 될 시점에 초기 값 세팅하도록 변경

## 📌 PR Point

- 무슨 이유로 어떻게 코드를 변경했는지
- 어떤 위험이나 우려가 발견되었는지
- 어떤 부분에 리뷰어가 집중해야 하는지
- 개발하면서 어떤 점이 궁금했는지

## 📸 스크린샷

https://github.com/user-attachments/assets/9d1471dd-1a28-4daa-904a-2c97525c2bc3

