### PR TITLE
[Hotfix] auth api Token 주입 방식 변경

### DIFF
--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -4,10 +4,14 @@ import { baseApi } from '@api/index';
 export const getCrewToken = async (playgroundToken: string) => {
   const response = await baseApi.post<
     paths['/auth/v2']['post']['responses']['201']['content']['application/json;charset=UTF-8']
-  >('/auth/v2', {
-    headers: {
-      Authorization: `Bearer ${playgroundToken}`,
-    },
-  });
+  >(
+    '/auth/v2',
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${playgroundToken}`,
+      },
+    }
+  );
   return response.data;
 };

--- a/src/api/auth/index.ts
+++ b/src/api/auth/index.ts
@@ -4,6 +4,10 @@ import { baseApi } from '@api/index';
 export const getCrewToken = async (playgroundToken: string) => {
   const response = await baseApi.post<
     paths['/auth/v2']['post']['responses']['201']['content']['application/json;charset=UTF-8']
-  >('/auth/v2', { authToken: playgroundToken });
+  >('/auth/v2', {
+    headers: {
+      Authorization: `Bearer ${playgroundToken}`,
+    },
+  });
   return response.data;
 };


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1161 

## 📋 작업 내용

- [x] auth api Token 주입 방식 변경


## 📌 PR Point

**AS-IS**
requetBody { "authToken" : "eydfaf......" }

**TO-BE**
플그 로컬스토리지에 있는 serviceAccessToken을 Authorization Header에 Bearer 형식으로 변경
Authorization: Bearer $#{token}

백엔드 요청사항에 따라 수정해서 올렸습니다. 

## 📸 스크린샷
