### PR TITLE
React Query v5로 버전업

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@sopt-makers/playground-common": "^1.7.3",
     "@sopt-makers/ui": "^2.8.12",
     "@stitches/react": "^1.2.8",
-    "@tanstack/react-query": "^4.10.3",
+    "@tanstack/react-query": "^5",
     "@types/autosize": "^4.0.3",
     "autosize": "^6.0.1",
     "axios": "^1.1.3",

--- a/pages/edit/flash/index.tsx
+++ b/pages/edit/flash/index.tsx
@@ -21,7 +21,7 @@ const FlashEditPage = () => {
   const id = +(router.query.id || 0);
 
   const { data: formData } = useFlashQuery({ meetingId: id });
-  const { mutateAsync, isLoading: isSubmitting } = usePutFlashMutation({ meetingId: id });
+  const { mutateAsync, isPending: isSubmitting } = usePutFlashMutation({ meetingId: id });
 
   const formMethods = useForm<FlashFormType>({
     mode: 'onChange',

--- a/pages/edit/index.tsx
+++ b/pages/edit/index.tsx
@@ -23,7 +23,7 @@ const EditPage = () => {
   const id = router.query.id as string;
 
   const { data: formData } = useMeetingQuery({ meetingId: Number(id) });
-  const { mutateAsync, isLoading: isSubmitting } = usePutMeetingMutation(Number(id));
+  const { mutateAsync, isPending: isSubmitting } = usePutMeetingMutation(Number(id));
 
   const formMethods = useForm<FormType>({
     mode: 'onChange',

--- a/pages/make/flash/index.tsx
+++ b/pages/make/flash/index.tsx
@@ -22,7 +22,7 @@ const Flash = () => {
     resolver: zodResolver(flashSchema),
   });
   const { isValid, errors, isDirty } = formMethods.formState;
-  const { mutateAsync: mutateCreateFlash, isLoading: isSubmitting } = usePostFlashMutation();
+  const { mutateAsync: mutateCreateFlash, isPending: isSubmitting } = usePostFlashMutation();
 
   const handleChangeImage = (index: number, url: string) => {
     const files = formMethods.getValues().files.slice();

--- a/pages/make/index.tsx
+++ b/pages/make/index.tsx
@@ -29,7 +29,7 @@ const MakePage = () => {
     },
   });
   const { isValid, errors, isDirty } = formMethods.formState;
-  const { mutateAsync: mutateCreateMeeting, isLoading: isSubmitting } = usePostMeetingMutation();
+  const { mutateAsync: mutateCreateMeeting, isPending: isSubmitting } = usePostMeetingMutation();
 
   const handleChangeImage = (index: number, url: string) => {
     const files = formMethods.getValues().files.slice();

--- a/pages/post/index.tsx
+++ b/pages/post/index.tsx
@@ -49,7 +49,7 @@ export default function PostPage() {
 
   const { parentComment } = useContext(MentionContext);
 
-  const { mutateAsync, isLoading: isCreatingComment } = usePostCommentMutation();
+  const { mutateAsync, isPending: isCreatingComment } = usePostCommentMutation();
 
   const { mutate: mutatePostCommentWithMention } = useMutationPostCommentWithMention({});
 

--- a/src/api/comment/mutation.ts
+++ b/src/api/comment/mutation.ts
@@ -18,7 +18,7 @@ export function usePutCommentMutation(postId: number) {
 
   return useMutation({
     mutationFn: ({ commentId, contents }: { commentId: number; contents: string }) => putComment(commentId, contents),
-    onSuccess: () => queryClient.invalidateQueries(CommentQueryKey.list(postId)),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: CommentQueryKey.list(postId) }),
   });
 }
 export function usePostCommentLikeMutation() {

--- a/src/api/meeting/hook.ts
+++ b/src/api/meeting/hook.ts
@@ -11,7 +11,7 @@ import {
   useSearchParams,
   useStatusParams,
 } from '@hooks/queryString/custom';
-import { UseQueryResult, useQuery } from '@tanstack/react-query';
+import { UseQueryResult, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { getMeeting, getMeetingList, getMeetingMemberList, getRecommendMeetingList } from '.';
 
 export const useMeetingListQuery = () => {
@@ -54,10 +54,9 @@ export const useMeetingListQuery = () => {
     params.query = search;
   }
 
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: MeetingQueryKey.list(params as GetMeetingList['request']),
     queryFn: () => getMeetingList(params as GetMeetingList['request']),
-    suspense: true,
   });
 };
 

--- a/src/api/post/hooks.ts
+++ b/src/api/post/hooks.ts
@@ -5,7 +5,8 @@ import { getPostDetail, getPostList } from '.';
 export const useGetPostListInfiniteQuery = (take: number, meetingId?: number, enabled?: boolean) => {
   return useInfiniteQuery({
     queryKey: PostQueryKey.list(take, meetingId),
-    queryFn: ({ pageParam = 1 }) => getPostList(pageParam, take, meetingId),
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) => getPostList(pageParam, take, meetingId),
     getNextPageParam: (lastPage, allPages) => {
       const posts = lastPage?.posts;
       if (!posts || posts.length === 0) {

--- a/src/api/post/mutation.ts
+++ b/src/api/post/mutation.ts
@@ -10,7 +10,7 @@ export const useDeletePostMutation = () => {
   return useMutation({
     mutationFn: (postId: number) => deletePost(postId),
     onSuccess: () => {
-      queryClient.invalidateQueries(PostQueryKey.all());
+      queryClient.invalidateQueries({ queryKey: PostQueryKey.all() });
     },
   });
 };
@@ -21,7 +21,7 @@ export const useUpdatePostLikeMutation = (take: number, meetingId?: number) => {
   return useMutation({
     mutationFn: (postId: number) => postPostLike(postId),
     onMutate: async postId => {
-      await queryClient.cancelQueries(PostQueryKey.list(take, meetingId));
+      await queryClient.cancelQueries({ queryKey: PostQueryKey.list(take, meetingId) });
 
       const previousPosts = queryClient.getQueryData(PostQueryKey.list(take, meetingId));
 
@@ -47,7 +47,7 @@ export const useUpdatePostLikeMutation = (take: number, meetingId?: number) => {
       queryClient.setQueryData(PostQueryKey.list(take, meetingId), context?.previousPosts);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries(PostQueryKey.all());
+      queryClient.invalidateQueries({ queryKey: PostQueryKey.all() });
     },
   });
 };

--- a/src/api/user/hooks.ts
+++ b/src/api/user/hooks.ts
@@ -1,5 +1,5 @@
 import UserQueryKey from '@api/user/UserQueryKey';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
   getInterestedKeywords,
   getUser,
@@ -7,8 +7,6 @@ import {
   getUserMeetingAll,
   getUserMeetingList,
   getUserProfile,
-  KeywordSettingOptionType,
-  postInterestedKeywords,
 } from '.';
 
 export const useUserQuery = () => {
@@ -30,17 +28,6 @@ export const useQueryGetInterestedKeywords = () => {
   return useQuery({
     queryKey: UserQueryKey.interestedKeywords(),
     queryFn: () => getInterestedKeywords(),
-  });
-};
-
-export const useMutationInterestedKeywords = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (keywords: KeywordSettingOptionType[]) => postInterestedKeywords(keywords),
-    onSuccess: () => {
-      queryClient.invalidateQueries(UserQueryKey.interestedKeywords());
-    },
   });
 };
 

--- a/src/api/user/mutation.ts
+++ b/src/api/user/mutation.ts
@@ -8,7 +8,7 @@ export const useMutationInterestedKeywords = () => {
   return useMutation({
     mutationFn: (keywords: KeywordSettingOptionType[]) => postInterestedKeywords(keywords),
     onSuccess: () => {
-      queryClient.invalidateQueries(UserQueryKey.interestedKeywords());
+      queryClient.invalidateQueries({ queryKey: UserQueryKey.interestedKeywords() });
     },
   });
 };

--- a/src/api/user/mutation.ts
+++ b/src/api/user/mutation.ts
@@ -1,6 +1,6 @@
 import UserQueryKey from '@api/user/UserQueryKey';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { KeywordSettingOptionType, postInterestedKeywords } from '.';
+import { getUserMeetingAll, KeywordSettingOptionType, postInterestedKeywords } from '.';
 
 export const useMutationInterestedKeywords = () => {
   const queryClient = useQueryClient();
@@ -9,6 +9,17 @@ export const useMutationInterestedKeywords = () => {
     mutationFn: (keywords: KeywordSettingOptionType[]) => postInterestedKeywords(keywords),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: UserQueryKey.interestedKeywords() });
+    },
+  });
+};
+
+export const useUserMeetingListMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: getUserMeetingAll,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: UserQueryKey.meetingAll() });
     },
   });
 };

--- a/src/components/FloatingButton/index.tsx
+++ b/src/components/FloatingButton/index.tsx
@@ -1,5 +1,5 @@
 import { ampli } from '@/ampli';
-import { getUserMeetingAll } from '@api/user';
+import { useUserMeetingListMutation } from '@api/user/mutation';
 import PlusIcon from '@assets/svg/plus.svg';
 import Plus from '@assets/svg/plus.svg?rect';
 import FeedCreateWithSelectMeetingModal from '@components/feed/Modal/FeedCreateWithSelectMeetingModal';
@@ -8,7 +8,6 @@ import FloatingButtonModal from '@components/modal/FloatingButtonModal';
 import NoJoinedGroupModal from '@components/modal/NoJoinedGroupModal';
 import { useDisplay } from '@hooks/useDisplay';
 import { useOverlay } from '@hooks/useOverlay/Index';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { styled } from 'stitches.config';
@@ -19,21 +18,7 @@ function FloatingButton() {
   const router = useRouter();
   const { modal } = router.query;
   const overlay = useOverlay();
-  const queryClient = useQueryClient();
-  const { mutate: fetchUserAttendMeetingListMutate } = useMutation(getUserMeetingAll, {
-    onSuccess: data => {
-      setIsActive(false);
-      router.push('/', undefined, { shallow: true });
-      queryClient.setQueryData(['fetchMeetingList', 'all'], data);
-      if (data.length === 0) {
-        overlay.open(({ isOpen, close }) => <NoJoinedGroupModal isModalOpened={isOpen} handleModalClose={close} />);
-      } else {
-        overlay.open(({ isOpen, close }) => (
-          <FeedCreateWithSelectMeetingModal isModalOpened={isOpen} handleModalClose={close} />
-        ));
-      }
-    },
-  });
+  const { mutate: fetchUserAttendMeetingListMutate } = useUserMeetingListMutation();
 
   const handleButtonClick = () => {
     if (!isActive) {
@@ -44,9 +29,21 @@ function FloatingButton() {
 
   useEffect(() => {
     if (modal === 'create-feed') {
-      fetchUserAttendMeetingListMutate();
+      fetchUserAttendMeetingListMutate(undefined, {
+        onSuccess: data => {
+          setIsActive(false);
+          router.push('/', undefined, { shallow: true });
+          if (data.length === 0) {
+            overlay.open(({ isOpen, close }) => <NoJoinedGroupModal isModalOpened={isOpen} handleModalClose={close} />);
+          } else {
+            overlay.open(({ isOpen, close }) => (
+              <FeedCreateWithSelectMeetingModal isModalOpened={isOpen} handleModalClose={close} />
+            ));
+          }
+        },
+      });
     }
-  }, [modal, fetchUserAttendMeetingListMutate]);
+  }, [modal, fetchUserAttendMeetingListMutate, router, overlay]);
 
   return (
     <>

--- a/src/components/feed/Modal/FeedCreateModal.tsx
+++ b/src/components/feed/Modal/FeedCreateModal.tsx
@@ -57,10 +57,10 @@ function FeedCreateModal({ isModalOpened, meetingId, handleModalClose }: CreateM
     basePath = 'https://playground.sopt.org';
   }
 
-  const { mutateAsync: mutateCreateFeed, isLoading: isSubmitting } = useMutation({
+  const { mutateAsync: mutateCreateFeed, isPending: isSubmitting } = useMutation({
     mutationFn: (formData: FormCreateType) => postPost(formData),
     onSuccess: res => {
-      queryClient.invalidateQueries(PostQueryKey.all());
+      queryClient.invalidateQueries({ queryKey: PostQueryKey.all() });
       alert('피드를 작성했습니다.');
       const mentionedOrgIds = parseMentionedUserIds(formMethods.getValues().contents);
       if (mentionedOrgIds.length > 0) {

--- a/src/components/feed/Modal/FeedCreateWithSelectMeetingModal.tsx
+++ b/src/components/feed/Modal/FeedCreateWithSelectMeetingModal.tsx
@@ -57,10 +57,10 @@ function FeedCreateWithSelectMeetingModal({ isModalOpened, handleModalClose }: C
     basePath = 'https://playground.sopt.org';
   }
 
-  const { mutateAsync: mutateCreateFeed, isLoading: isSubmitting } = useMutation({
+  const { mutateAsync: mutateCreateFeed, isPending: isSubmitting } = useMutation({
     mutationFn: (formData: FormCreateType) => postPost(formData),
     onSuccess: res => {
-      queryClient.invalidateQueries(PostQueryKey.all());
+      queryClient.invalidateQueries({ queryKey: PostQueryKey.all() });
       alert('피드를 작성했습니다.');
       mutatePostPostWithMention({
         postId: res.postId,

--- a/src/components/feed/Modal/FeedEditModal.tsx
+++ b/src/components/feed/Modal/FeedEditModal.tsx
@@ -37,11 +37,11 @@ function FeedEditModal({ isModalOpened, postId, handleModalClose }: EditModal) {
 
   const { isValid } = formMethods.formState;
 
-  const { mutateAsync: mutateEditFeed, isLoading: isSubmitting } = useMutation({
+  const { mutateAsync: mutateEditFeed, isPending: isSubmitting } = useMutation({
     mutationFn: (formData: FormEditType) => putPost(postId, formData),
     onSuccess: () => {
-      queryClient.invalidateQueries(PostQueryKey.detail(postId));
-      queryClient.invalidateQueries(PostQueryKey.all());
+      queryClient.invalidateQueries({ queryKey: PostQueryKey.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: PostQueryKey.all() });
       alert('피드를 수정했습니다.');
       submitModal.handleModalClose();
       handleModalClose();

--- a/src/components/page/detail/Feed/FeedPanel.tsx
+++ b/src/components/page/detail/Feed/FeedPanel.tsx
@@ -76,7 +76,7 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   const postCount = postsData?.total;
-  const formattedPostCount = postCount > POST_MAX_COUNT ? `${POST_MAX_COUNT}+` : postCount;
+  const formattedPostCount = postCount && postCount > POST_MAX_COUNT ? `${POST_MAX_COUNT}+` : postCount;
 
   const handleModalOpen = () => {
     if (me?.orgId) {
@@ -178,7 +178,7 @@ const FeedPanel = ({ isMember }: FeedPanelProps) => {
         </SContainer>
       )}
 
-      {postCount > 0 && (
+      {postCount && postCount > 0 && (
         <SHeader>
           <p>
             🔥 지금까지 쌓인 피드 <SCount>{formattedPostCount}</SCount>개

--- a/yarn.lock
+++ b/yarn.lock
@@ -7725,29 +7725,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:4.10.3":
-  version: 4.10.3
-  resolution: "@tanstack/query-core@npm:4.10.3"
-  checksum: 10c0/766d0b3c2c591177cf7f0f3b4a9446c8485a680052f34630e121a98b30a9d95542efb02b2d67a0307b82c056677d914a116a319165e158cbbaa03f61a67b2708
+"@tanstack/query-core@npm:5.85.5":
+  version: 5.85.5
+  resolution: "@tanstack/query-core@npm:5.85.5"
+  checksum: 10c0/344670ac117bc4775a9e812fc91e27befc9ef4f681e341d8f76af3cd075eecdcc5aa058a9544a6b56cccb8e07f22ef5c9e0c852331d428bcce5e1223deef14bd
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:^4.10.3":
-  version: 4.10.3
-  resolution: "@tanstack/react-query@npm:4.10.3"
+"@tanstack/react-query@npm:^5":
+  version: 5.85.5
+  resolution: "@tanstack/react-query@npm:5.85.5"
   dependencies:
-    "@tanstack/query-core": "npm:4.10.3"
-    use-sync-external-store: "npm:^1.2.0"
+    "@tanstack/query-core": "npm:5.85.5"
   peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-native: "*"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 10c0/6663590a15575f68cd851ed5009ebcc9b174330fa472752e03e0ccd978b7356cf2979a12cbb286d156b06045be1c0cde808c24609620b73be5ec82a58753c725
+    react: ^18 || ^19
+  checksum: 10c0/7518cd624f9fe7c258b460192a73021a1e7fe0e0ea4173de69ca0a69cf60cc812bdb59b13c7f9acdbf45f4f0e82e8efb1e739528cf26e334e4a80606d7c7050d
   languageName: node
   linkType: hard
 
@@ -20200,7 +20192,7 @@ __metadata:
     "@storybook/react": "npm:^8.1.11"
     "@storybook/testing-library": "npm:^0.0.14-next.2"
     "@svgr/webpack": "npm:^6.5.0"
-    "@tanstack/react-query": "npm:^4.10.3"
+    "@tanstack/react-query": "npm:^5"
     "@types/autosize": "npm:^4.0.3"
     "@types/node": "npm:18.8.3"
     "@types/react": "npm:18.0.21"
@@ -21837,15 +21829,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/89f0018fd9aee1fc17c85ac18c4bf8944d460d453d0d0e04ddbc8eaddf3fa591e9c74a1f8a438a1bff368a7a2417fab380bdb3df899d2194c4375b0982736de0
-  languageName: node
-  linkType: hard
-
-"use-sync-external-store@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "use-sync-external-store@npm:1.2.0"
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/ac4814e5592524f242921157e791b022efe36e451fe0d4fd4d204322d5433a4fc300d63b0ade5185f8e0735ded044c70bcf6d2352db0f74d097a238cebd2da02
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🚩 관련 이슈

- close #1168 

## 📋 작업 내용

### v4 → v5 체크리스트
- isLoading → isPending
  - query/mutation 모두: `isLoading` 대신 `isPending`
  - query의 재요청 진행 여부는 그대로 `isFetching`
- useInfiniteQuery: initialPageParam 필수
  - `initialPageParam: 1`
- `cacheTime` → `gcTime`로 옵션명 변경
- keepPreviousData 제거
  - 대체: `placeholderData: keepPreviousData` 유틸 사용
- invalidateQueries 호출 방식 정규화
  - 배열 직접 전달 지양 → 객체 형태로 전달
  - 예: `queryClient.invalidateQueries({ queryKey: PostQueryKey.all() })`
- queryOptions/infiniteQueryOptions 도입
  - 옵션 팩토리 사용 시 v5에서만 제공. v4 유지 시 직접 객체 리턴 (이 경우 타입 체크가 안 됨 ㅜㅜ) <- 버전업하려는 주 목적
- 상태(status) 문자열 변경
  - `'loading'` → `'pending'`
- 중단(Abort) 신호
  - v5는 `queryFn` 컨텍스트에 `signal` 제공. `fetch` 사용 시 `signal` 연결 권장
- SSR Hydration 컴포넌트 변경 권장
  - `Hydrate` → `HydrationBoundary`(v5 권장 방식)
