### PR TITLE
모임 게시글 상세 페이지에서 좋아요 클릭 안 되는 이슈 해결

### DIFF
--- a/src/api/post/PostQueryKey.ts
+++ b/src/api/post/PostQueryKey.ts
@@ -3,7 +3,6 @@ const PostQueryKey = {
   list: (take: number, meetingId?: number) => [...PostQueryKey.all(), take, meetingId] as const,
   detail: (id: number) => [...PostQueryKey.all(), id] as const,
   count: (meetingId: number) => [...PostQueryKey.list(meetingId), 'count'] as const,
-  mutate: (queryId: string) => [...PostQueryKey.all(), queryId] as const,
 };
 
 export default PostQueryKey;

--- a/src/api/post/mutation.ts
+++ b/src/api/post/mutation.ts
@@ -81,5 +81,8 @@ export const usePostLikeMutation = (queryId: string) => {
         queryClient.setQueryData(PostQueryKey.detail(+queryId), context?.previousPost);
       }
     },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: PostQueryKey.detail(+queryId) });
+    },
   });
 };

--- a/src/api/post/mutation.ts
+++ b/src/api/post/mutation.ts
@@ -77,9 +77,5 @@ export const usePostLikeMutation = (queryId: string) => {
     onError: (err, _, context) => {
       queryClient.setQueryData(PostQueryKey.detail(+queryId), context?.previousPost);
     },
-
-    // onSettled: () => {
-    //   queryClient.invalidateQueries({ queryKey: PostQueryKey.detail(+queryId) });
-    // },
   });
 };

--- a/src/api/post/mutation.ts
+++ b/src/api/post/mutation.ts
@@ -62,9 +62,11 @@ export const usePostLikeMutation = (queryId: string) => {
 
       const previousPost = queryClient.getQueryData<GetPostDetailResponse>(PostQueryKey.detail(+queryId));
 
-      queryClient.setQueryData(PostQueryKey.detail(+queryId), (oldData: GetPostDetailResponse | undefined) => {
-        if (!oldData) return;
+      if (!previousPost) {
+        return { previousPost: null };
+      }
 
+      queryClient.setQueryData(PostQueryKey.detail(+queryId), (oldData: GetPostDetailResponse) => {
         return produce(oldData, draft => {
           draft.isLiked = !oldData.isLiked;
           draft.likeCount = oldData.isLiked ? oldData.likeCount - 1 : oldData.likeCount + 1;

--- a/src/api/post/mutation.ts
+++ b/src/api/post/mutation.ts
@@ -59,7 +59,7 @@ export const usePostLikeMutation = (queryId: string) => {
     mutationKey: PostQueryKey.mutate(queryId),
     mutationFn: () => postPostLike(+queryId),
     onMutate: async () => {
-      const previousPost = queryClient.getQueryData(PostQueryKey.mutate(queryId)) as GetPostDetailResponse;
+      const previousPost = queryClient.getQueryData(PostQueryKey.detail(+queryId)) as GetPostDetailResponse;
 
       const newLikeCount = previousPost.isLiked ? previousPost.likeCount - 1 : previousPost.likeCount + 1;
 
@@ -68,7 +68,7 @@ export const usePostLikeMutation = (queryId: string) => {
         draft.likeCount = newLikeCount;
       });
 
-      queryClient.setQueryData(PostQueryKey.mutate(queryId), data);
+      queryClient.setQueryData(PostQueryKey.detail(+queryId), data);
     },
   });
 };

--- a/src/api/post/mutation.ts
+++ b/src/api/post/mutation.ts
@@ -56,7 +56,6 @@ export const usePostLikeMutation = (queryId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationKey: PostQueryKey.mutate(queryId),
     mutationFn: () => postPostLike(+queryId),
     onMutate: async () => {
       const previousPost = queryClient.getQueryData(PostQueryKey.detail(+queryId)) as GetPostDetailResponse;

--- a/src/api/post/mutation.ts
+++ b/src/api/post/mutation.ts
@@ -60,7 +60,7 @@ export const usePostLikeMutation = (queryId: string) => {
     onMutate: async () => {
       await queryClient.cancelQueries({ queryKey: PostQueryKey.detail(+queryId) });
 
-      const previousPost = queryClient.getQueryData(PostQueryKey.detail(+queryId)) as GetPostDetailResponse;
+      const previousPost = queryClient.getQueryData<GetPostDetailResponse>(PostQueryKey.detail(+queryId));
 
       queryClient.setQueryData(PostQueryKey.detail(+queryId), (oldData: GetPostDetailResponse | undefined) => {
         if (!oldData) return;

--- a/src/api/post/mutation.ts
+++ b/src/api/post/mutation.ts
@@ -75,7 +75,9 @@ export const usePostLikeMutation = (queryId: string) => {
     },
 
     onError: (err, _, context) => {
-      queryClient.setQueryData(PostQueryKey.detail(+queryId), context?.previousPost);
+      if (context?.previousPost) {
+        queryClient.setQueryData(PostQueryKey.detail(+queryId), context?.previousPost);
+      }
     },
   });
 };


### PR DESCRIPTION

## 📋 작업 내용

- [x] previousPosts queryKey 변경
- [x] error 처리 추가

## 📌 PR Point
### 문제 해결 과정
일단 해당 좋야요 클릭이 안되는 이슈는 확인한 결과 API 요청 자체를 하지 않는 것으로 확인했어요. `console`위치를 바꿔가면서 디버깅을 해본 결과로는 `onMutate`안에서는 뜨지만, `mutationFn`인 `postPostLike`안에서는 안 찍혔기 때문이에요.

즉,
```tsx
usePostLikeMutation -> useMutation -> onMutate -> postPostLike 
```
헤당 순서대로 코드 실행이 될텐데 `postPostLike`까지 코드 실행이 가지 못하고 `onMutate`에서 이슈가 생겼다는 것으로 판단했어요. 실제로 낙관적 업데이트를 위한 `previousPost`가 `undefined`로 찍히는 것을 확인했고, 한마디로 캐싱된 데이터가 없다는 것인데 그 이유는 피드 게시글(post)의 쿼리키와 `getQueryData`를 할 때의 쿼리키가 다르기 때문이에요. 

따라서 `PostQueryKey.mutate`를 `PostQueryKey.detail`로 수정해서 해결했어요.

<br/>


### 예외 처리 추가
그리고 해당 mutate가 에러 관련 처리가 안 되어 있어서 추가했어요. 낙관적 업데이트로 UI를 미리 변경한 상태기 때문에 에러가 발생하면 onMutate에서 미리 저장해둔 이전 데이터로 해줬어요.

```tsx
onError: (err, _, context) => {
  queryClient.setQueryData(PostQueryKey.detail(+queryId), context?.previousPost);
},
```

<br/>

## 📸 스크린샷

https://github.com/user-attachments/assets/8cf5f16e-051c-4a49-8b84-00c19f835371

