### PR TITLE
홈 모임 카드 (desktop/mobile) 전체 파트 표시 기능 추가

### DIFF
--- a/src/domain/home/HomeCardList/DesktopCard.tsx
+++ b/src/domain/home/HomeCardList/DesktopCard.tsx
@@ -29,6 +29,9 @@ const DesktopCard = ({
   canJoinOnlyActiveGeneration,
   joinableParts,
 }: DesktopCardProps) => {
+  const isAllParts = joinableParts.length === 6 || joinableParts === null;
+  const displayParts = isAllParts ? '전체 파트' : joinableParts.map(part => PART_NAME[part]).join(', ');
+
   return (
     <Link href={`/detail?id=${id}`}>
       <SCardWrapper>
@@ -45,9 +48,7 @@ const DesktopCard = ({
         <SMetaWrapper>
           <UserIcon />
           <SInfoStyle>{`${approvedCount}/${capacity}명`}</SInfoStyle>
-          <SInfoStyle>{`${canJoinOnlyActiveGeneration ? '활동 기수' : '전체 기수'} / ${joinableParts.map(
-            part => PART_NAME[part]
-          )}`}</SInfoStyle>
+          <SInfoStyle>{`${canJoinOnlyActiveGeneration ? '활동 기수' : '전체 기수'} / ${displayParts}`}</SInfoStyle>
         </SMetaWrapper>
       </SCardWrapper>
     </Link>

--- a/src/domain/home/HomeCardList/MobileCard.tsx
+++ b/src/domain/home/HomeCardList/MobileCard.tsx
@@ -29,6 +29,9 @@ const MobileCard = ({
   canJoinOnlyActiveGeneration,
   joinableParts,
 }: MobileCardProps) => {
+  const isAllParts = joinableParts.length === 6 || joinableParts === null;
+  const displayParts = isAllParts ? '전체 파트' : joinableParts.map(part => PART_NAME[part]).join(', ');
+
   return (
     <Link href={`/detail?id=${id}`}>
       <SCardWrapper>
@@ -40,9 +43,7 @@ const MobileCard = ({
             <UserIcon width="16" height="16" style={{ alignContent: 'center', marginRight: '6px' }} />
             <SInfoStyle style={{ whiteSpace: 'nowrap' }}>{`${approvedCount}/${capacity}명`}</SInfoStyle>
             <SMetaSubStyle>·</SMetaSubStyle>
-            <SInfoStyle>{`${canJoinOnlyActiveGeneration ? '활동 기수' : '전체 기수'} / ${joinableParts.map(
-              part => PART_NAME[part]
-            )}`}</SInfoStyle>
+            <SInfoStyle>{`${canJoinOnlyActiveGeneration ? '활동 기수' : '전체 기수'} / ${displayParts}`}</SInfoStyle>
           </Flex>
           <Flex align="center">
             <Avatar


### PR DESCRIPTION
## 📋 작업 내용

- [x] 홈 모임 카드 (desktop/mobile) 전체 파트 표시 기능 추가

## 📌 PR Point
`joinableParts`의 `length`로 판단해서 전체 파트 분기처리를 했어요. 

```tsx
const isAllParts = joinableParts.length === 6 || joinableParts === null;
const displayParts = isAllParts ? '전체 파트' : joinableParts.map(part => PART_NAME[part]).join(', ');

// ... 

<SInfoStyle>{`${canJoinOnlyActiveGeneration ? '활동 기수' : '전체 기수'} / ${displayParts}`}</SInfoStyle>
```

여기서 제가 고민한 점이 2가지가 있어요.
1. client에서 해당 로직을 length로 비교해서 처리하는 것이 맞는가? 좋은 패턴인가?
2. 6은 매직 넘버이니 상수화 해야할텐데 폴더/파일을 어디에 두는가?

일단 1번을 생각하면 간단하게 서버에서 해당 값을 비교해서 `response`에 `boolean`값을 하나 추가해서 받으면 그걸 분기처리하거나, 지금처럼 클라이언트에서 직접 비교해서 하거나 둘 중 하나라고 생각했어요.

사실 상수로 max 파트 개수를 분리만 해서 중앙화하면 서버에서 하든, 클라이언트에서 하든 상관 없을 것이라고 생각했는데 더 좋은 패턴이 무엇일지 고민되네요. 

그리고 2번은 무조건 해당 `number` 값은 상수로 분리해두는 것이 맞다고 판단했어요. 이 숫자가 전체모임 탭에 있는 카드 등 다양한 곳에서 쓰이기 때문이에요. 그래서 이를 분리하고 싶은데 폴더/파일 구조와 네이밍을 어떻게 잡는 것이 좋을지 감이 안잡혀서 조언을 구해보고자 합니다....



## 📸 스크린샷
<img width="717" height="367" alt="image" src="https://github.com/user-attachments/assets/e75e3dae-cb58-4bf3-801d-6f79188895e2" />

<img width="639" height="393" alt="image" src="https://github.com/user-attachments/assets/0fef1770-a420-43ee-a460-c5435eba4089" />



