### PR TITLE
모임 개설 SOPT 공식 일정 확인하기 툴팁 37기 공식일정 기준으로 변경

### DIFF
--- a/src/shared/form/Presentation/ActivityPeriodField/OfficialScheduleTooltop.tsx
+++ b/src/shared/form/Presentation/ActivityPeriodField/OfficialScheduleTooltop.tsx
@@ -8,17 +8,17 @@ import { styled } from 'stitches.config';
 const schedule: React.ReactNode = (
   <>
     • 1~8차 세미나 <br />
-    &nbsp;&nbsp;&nbsp;2025.04.05 ~ 2025.06.21 <br />
+    &nbsp;&nbsp;&nbsp;2025.10.11 ~ 2025.12.27 <br />
     • 솝커톤 <br />
-    &nbsp;&nbsp;&nbsp;2025.05.17 ~ 2025.05.18 <br />
+    &nbsp;&nbsp;&nbsp;2025.11.22 ~ 2025.11.23 <br />
     • 네트워킹 행사 <br />
-    &nbsp;&nbsp;&nbsp;2025.05.31 <br />
+    &nbsp;&nbsp;&nbsp;2025.12.06 <br />
     • 기획 경선 <br />
-    &nbsp;&nbsp;&nbsp;2025.06.07 <br />
+    &nbsp;&nbsp;&nbsp;2025.12.13 <br />
     • 앱잼 <br />
-    &nbsp;&nbsp;&nbsp;2025.06.14 ~ 2025.07.19 <br />
+    &nbsp;&nbsp;&nbsp;2025.12.20 ~ 2026.01.24 <br />
     • 종무식 <br />
-    &nbsp;&nbsp;&nbsp;2025.07.26
+    &nbsp;&nbsp;&nbsp;2026.01.31
   </>
 );
 

--- a/src/shared/form/Presentation/ActivityPeriodField/OfficialScheduleTooltop.tsx
+++ b/src/shared/form/Presentation/ActivityPeriodField/OfficialScheduleTooltop.tsx
@@ -72,8 +72,8 @@ const OfficialScheduleTooltip = () => {
             <TextStyle>• 솝커톤: 2025.11.22 ~ 2025.11.23</TextStyle>
             <TextStyle>• 네트워킹 행사: 2025.12.06</TextStyle>
             <TextStyle>• 기획 경선: 2025.12.13</TextStyle>
-            <TextStyle>• 앱잼: 2025.12.20 ~ 2025.01.24</TextStyle>
-            <TextStyle>• 종무식: 2025.01.31</TextStyle>
+            <TextStyle>• 앱잼: 2025.12.20 ~ 2026.01.24</TextStyle>
+            <TextStyle>• 종무식: 2026.01.31</TextStyle>
           </TextDiv>
         </ToolTipDiv>
       )}

--- a/src/shared/form/Presentation/ActivityPeriodField/OfficialScheduleTooltop.tsx
+++ b/src/shared/form/Presentation/ActivityPeriodField/OfficialScheduleTooltop.tsx
@@ -68,12 +68,12 @@ const OfficialScheduleTooltip = () => {
             <BubblePointIcon />
           </PointDiv>
           <TextDiv>
-            <TextStyle>• 1~8차 세미나: 2025.04.05 ~ 2025.06.21</TextStyle>
-            <TextStyle>• 솝커톤: 2025.05.17 ~ 2025.05.18</TextStyle>
-            <TextStyle>• 네트워킹 행사: 2025.05.31</TextStyle>
-            <TextStyle>• 기획 경선: 2025.06.07</TextStyle>
-            <TextStyle>• 앱잼: 2025.06.14 ~ 2025.07.19</TextStyle>
-            <TextStyle>• 종무식: 2025.07.26</TextStyle>
+            <TextStyle>• 1~8차 세미나: 2025.10.11 ~ 2025.12.27</TextStyle>
+            <TextStyle>• 솝커톤: 2025.11.22 ~ 2025.11.23</TextStyle>
+            <TextStyle>• 네트워킹 행사: 2025.12.06</TextStyle>
+            <TextStyle>• 기획 경선: 2025.12.13</TextStyle>
+            <TextStyle>• 앱잼: 2025.12.20 ~ 2025.01.24</TextStyle>
+            <TextStyle>• 종무식: 2025.01.31</TextStyle>
           </TextDiv>
         </ToolTipDiv>
       )}


### PR DESCRIPTION
## 📋 작업 내용

- [x] 툴팁 텍스트 변경

## 📌 PR Point
모임 개설에 있는 `SOPT 공식 일정 확인하기` 툴팁 37기 공식일정 기준으로 변경했습니다~~

## 📸 스크린샷
<img width="313" height="268" alt="image" src="https://github.com/user-attachments/assets/dd2f3411-6ba5-4817-b2b9-659b69b68726" />

<img width="297" height="222" alt="image" src="https://github.com/user-attachments/assets/97ac5675-b6e7-4f14-8d3b-10bb04f3b992" />
