### PR TITLE
모임 홈 스터디 카드 제목 타이포그래피 수정

### DIFF
--- a/src/domain/home/HomeCardList/DesktopCard.tsx
+++ b/src/domain/home/HomeCardList/DesktopCard.tsx
@@ -1,6 +1,7 @@
 import UserIcon from '@assets/svg/user.svg?rect';
 import Avatar from '@common/avatar/Avatar';
 import { PART_NAME } from '@constant/option';
+import { fontsObject } from '@sopt-makers/fonts';
 import { getResizedImage } from '@util/image';
 import Link from 'next/link';
 import { styled } from 'stitches.config';
@@ -78,7 +79,7 @@ const SThumbnailImage = styled('img', {
 const STitleStyle = styled('h3', {
   padding: '$4 0 $8',
 
-  textStyle: 'H4',
+  ...fontsObject.HEADING_6_18_B,
 });
 
 const SMetaWrapper = styled('div', {


### PR DESCRIPTION
## 📋 작업 내용

- [x] typo mds fontsObject로 변경
- [x] HEADING_6_18_B로 typo 변경

## 📌 PR Point
모임 홈 스터디 카드 제목 타이포그래피 `HEADING_6_18_B`로 수정했습니다!

## 📸 스크린샷
### AS-IS
<img width="315" height="280" alt="image" src="https://github.com/user-attachments/assets/78f13187-2f32-4f6e-8014-cf61c26550aa" />


### TO-BE
<img width="315" height="293" alt="image" src="https://github.com/user-attachments/assets/62005a65-f1a0-4024-8382-17ad845e32ab" />

