### PR TITLE
모임 홈 레이아웃 수정

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,7 @@ import { useInView } from 'react-intersection-observer';
 import { styled } from 'stitches.config';
 
 const Home: NextPage = () => {
-  const { isLaptop, isTablet, isMobile } = useDisplay();
+  const { isLaptop, isTablet } = useDisplay();
 
   const { ref, inView } = useInView();
 
@@ -39,7 +39,7 @@ const Home: NextPage = () => {
         <GuideButton />
       </CrewTab>
       {isLoading && (isTablet ? <MobileFeedListSkeleton count={3} /> : <DesktopFeedListSkeleton row={3} column={3} />)}
-      {isMobile ? (
+      {isTablet ? (
         <>
           <SContentTitle style={{ marginTop: '16px' }}>⚡ 솝트만의 일회성 모임, 번쩍</SContentTitle>
           {flashList && <GroupBrowsingSlider cardList={flashList}></GroupBrowsingSlider>}
@@ -93,15 +93,10 @@ const SContentTitle = styled('div', {
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  width: '1200px',
-
-  '@laptop': {
-    width: '790px',
-  },
+  width: '100%',
 
   '@mobile': {
     display: 'flex',
-    width: '100%',
     fontSize: '16px',
   },
 });

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -63,7 +63,7 @@ const Home: NextPage = () => {
         </Flex>
       ) : (
         <>
-          <Flex justify="center" style={{ marginTop: '72px' }}>
+          <Flex justify="between" style={{ marginTop: '72px' }}>
             <HomeCardList />
             <div style={{ paddingLeft: '106px' }}>
               <QuickMenu />

--- a/src/shared/groupBrowsing/Carousel/Carousel.tsx
+++ b/src/shared/groupBrowsing/Carousel/Carousel.tsx
@@ -95,8 +95,8 @@ const SCarousel = styled('div', {
   },
 
   '.slick-list': {
-    width: '1220px',
-    minWidth: '1220px',
+    width: '1200px',
+    minWidth: '1200px',
 
     '& a': {
       flexType: 'center',
@@ -120,14 +120,15 @@ const SCarousel = styled('div', {
   },
 
   '.slick-prev': {
-    mr: '24px',
+    '@laptop': {
+      left: '-64px',
+    },
   },
 
   '.slick-next': {
     transform: 'rotate(180deg)',
-    mr: '17px',
     '@laptop': {
-      mr: '0px',
+      right: '-64px',
     },
   },
 });

--- a/src/shared/groupBrowsingSlider/groupBrowsingSlider.tsx
+++ b/src/shared/groupBrowsingSlider/groupBrowsingSlider.tsx
@@ -21,5 +21,5 @@ export default GroupBrowsingSlider;
 const SSlider = styled('div', {
   display: 'flex',
   gap: '$12',
-  overflowX: 'auto',
+  overflow: 'auto hidden',
 });


### PR DESCRIPTION
## 📋 작업 내용

- [x] 레이아웃 안맞는 문제 해결
- [x] 반응형 레이아웃 깨지는 문제 해결

## 📌 PR Point

- 모임 홈에서 '⚡ 솝트만의 일회성 모임, 번쩍' 과 '🔥 36기, 지금 가장 HOT한 모임 둘러보기' 의 왼쪽 시작이 안맞는 문제 해결했습니다.
- 너비 `431px` ~ `840px` 구간에서 스크롤 형식이어야 하는데, 캐러셀로 나오며 레이아웃이 깨지는 문제 해결했습니다.
- `841px` ~ `1259px` 구간에서 좌우 버튼 위치가 이상했음.
    <img width="906" height="719" alt="image" src="https://github.com/user-attachments/assets/d4771498-3cc6-4a81-b86d-ab38fe070760" />
    
    피그마 디자인 처럼 좌우로 10px 씩 삐져나오게 수정
    <img width="661" height="209" alt="image" src="https://github.com/user-attachments/assets/07304e8e-24e1-48db-b94b-e62025c19a3b" />

    <img width="848" height="275" alt="image" src="https://github.com/user-attachments/assets/a0806276-a415-4cef-a90b-2342f580bb07" />



## 📸 스크린샷

<img width="1318" height="640" alt="image" src="https://github.com/user-attachments/assets/9a37495f-623d-4bdb-ab51-1aeea0034175" />
이제 왼쪽 라인 맞아요!

https://github.com/user-attachments/assets/3ec1d6b1-3b23-4f7d-9666-454c4159edd7

