### PR TITLE
신청자 리스트 필터링/정렬/페이지네이션 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@storybook/react": "^8.1.11",
     "@storybook/testing-library": "^0.0.14-next.2",
     "@svgr/webpack": "^6.5.0",
+    "@tanstack/react-query-devtools": "^5",
     "@types/node": "18.8.3",
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,7 @@ import { setAccessTokens } from '@shared/util/auth';
 import { DialogProvider, ToastProvider } from '@sopt-makers/ui';
 import '@sopt-makers/ui/dist/index.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { GTM_ID, pageview } from '@util/gtm';
 import type { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
@@ -101,6 +102,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       <MentionProvider>
         <QueryClientProvider client={queryClient}>
           <SEO />
+          {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
           <Script
             id="gtag-base"
             strategy="afterInteractive"

--- a/pages/mine/management/index.tsx
+++ b/pages/mine/management/index.tsx
@@ -6,7 +6,7 @@ import ManagementForGuest from '@domain/mine/management/ManagementForGuest';
 import ManagementForHost from '@domain/mine/management/ManagementForHost';
 import MeetingInformation from '@domain/mine/management/MeetingInformation';
 import MeetingInformationSkeleton from '@domain/mine/management/Skeleton/MeetingInformationSkeleton';
-import { usePageParams, useSortByDateParams, useStatusParams, useTakeParams } from '@hook/queryString/custom';
+import { usePageParams, useSortByDateParams, useTakeParams } from '@hook/queryString/custom';
 import CrewTab from '@shared/CrewTab';
 import { Option } from '@shared/form/Select/OptionItem';
 import { useQuery } from '@tanstack/react-query';
@@ -18,7 +18,6 @@ const ManagementPage = () => {
   const id = router.query.id as string;
 
   const { value: page, setValue: setPage } = usePageParams();
-  const { value: status } = useStatusParams();
   const { value: take, setValue: setTake } = useTakeParams();
   const { value: sortByDate, setValue: setSort } = useSortByDateParams();
 
@@ -34,12 +33,6 @@ const ManagementPage = () => {
   const { isLoading: isManagementDataLoading, data: management } = useQuery(
     useMeetingMemberListQueryOption({
       meetingId: id,
-      params: {
-        page: Number(page),
-        take: Number(convertedNumberTake.value),
-        status: status.join(','),
-        date: sortOptionList[Number(sortByDate) || 1]?.value as 'desc' | 'asc',
-      },
     })
   );
 
@@ -69,7 +62,7 @@ const ManagementPage = () => {
       ) : (
         meetingData && <MeetingInformation meetingData={meetingData} />
       )}
-      {management && management.meta?.pageCount > 0 && (
+      {management && (
         <>
           {isHost ? (
             <ManagementForHost

--- a/src/api/meeting/MeetingQueryKey.ts
+++ b/src/api/meeting/MeetingQueryKey.ts
@@ -1,10 +1,11 @@
-import { GetMeetingList } from '@api/meeting/type';
+import { GetMeetingList, GetMeetingMemberList } from '@api/meeting/type';
 
 const MeetingQueryKey = {
   all: () => ['meeting'] as const,
   list: (params?: GetMeetingList['request']) => [...MeetingQueryKey.all(), params] as const,
   detail: (meetingId: number) => [...MeetingQueryKey.all(), meetingId] as const,
-  memberList: () => [...MeetingQueryKey.all(), 'memberList'] as const,
+  memberList: (meetingId: string, params?: GetMeetingMemberList['request']) =>
+    [...MeetingQueryKey.all(), 'memberList', meetingId, params] as const,
   recommendList: (meetingIds: number[]) => [...MeetingQueryKey.all(), 'recommendList', meetingIds] as const,
 };
 

--- a/src/api/meeting/mutation.ts
+++ b/src/api/meeting/mutation.ts
@@ -53,14 +53,14 @@ export const useDeleteMeetingApplicationMutation = () => {
   });
 };
 
-export const useUpdateMeetingApplicationMutation = () => {
+export const useUpdateMeetingApplicationMutation = (meetingId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: updateMeetingApplication,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: MeetingQueryKey.memberList(),
+        queryKey: MeetingQueryKey.memberList(meetingId),
       });
     },
     onError: (error: unknown) => {

--- a/src/api/meeting/query.ts
+++ b/src/api/meeting/query.ts
@@ -79,7 +79,7 @@ export const useMeetingMemberListQueryOption = ({
   delete params?.status;
 
   return queryOptions<GetMeetingMemberList['response']>({
-    queryKey: MeetingQueryKey.memberList(),
+    queryKey: MeetingQueryKey.memberList(meetingId, params),
     queryFn: () => {
       return getMeetingMemberList({ params, meetingId });
     },

--- a/src/domain/mine/management/ManagementForHost/ManagementListItemForHost.tsx
+++ b/src/domain/mine/management/ManagementForHost/ManagementListItemForHost.tsx
@@ -28,7 +28,7 @@ const ManagementListItemForHost = ({ meetingId, application }: ManagementListIte
   const date = dayjs(appliedDate).format('YY.MM.DD');
   const time = dayjs(appliedDate).format('HH:mm:ss');
 
-  const { mutate: mutateUpdateApplication } = useUpdateMeetingApplicationMutation();
+  const { mutate: mutateUpdateApplication } = useUpdateMeetingApplicationMutation(meetingId);
   const [isMutateLoading, setIsMutateLoading] = useState(false);
 
   const handleChangeApplicationStatus = (status: number) => () => {

--- a/src/domain/mine/management/ManagementForHost/ManagementListItemForHost.tsx
+++ b/src/domain/mine/management/ManagementForHost/ManagementListItemForHost.tsx
@@ -28,7 +28,7 @@ const ManagementListItemForHost = ({ meetingId, application }: ManagementListIte
   const date = dayjs(appliedDate).format('YY.MM.DD');
   const time = dayjs(appliedDate).format('HH:mm:ss');
 
-  const { mutate: mutateUpdateApplication } = useUpdateMeetingApplicationMutation(meetingId);
+  const { mutate: mutateUpdateApplication } = useUpdateMeetingApplicationMutation(meetingId + '');
   const [isMutateLoading, setIsMutateLoading] = useState(false);
 
   const handleChangeApplicationStatus = (status: number) => () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7732,6 +7732,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/query-devtools@npm:5.90.1":
+  version: 5.90.1
+  resolution: "@tanstack/query-devtools@npm:5.90.1"
+  checksum: 10c0/3b69e5441438acf0e753adbf187abf54b5b2e19d7c6d1e465d97278cb8c248bb86d3be193092d50414e4093cbf014093103517cb523daae003e53c867f3c11c2
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-query-devtools@npm:^5":
+  version: 5.90.2
+  resolution: "@tanstack/react-query-devtools@npm:5.90.2"
+  dependencies:
+    "@tanstack/query-devtools": "npm:5.90.1"
+  peerDependencies:
+    "@tanstack/react-query": ^5.90.2
+    react: ^18 || ^19
+  checksum: 10c0/526d529bf995426ace7511f51a425ce92dfc1b6dd74c9956a3cd7d68950119e97291bced2ff17173bcdb329eae36c68abc211a4dec32d6e92ab537b41c0533c2
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-query@npm:^5":
   version: 5.85.5
   resolution: "@tanstack/react-query@npm:5.85.5"
@@ -20193,6 +20212,7 @@ __metadata:
     "@storybook/testing-library": "npm:^0.0.14-next.2"
     "@svgr/webpack": "npm:^6.5.0"
     "@tanstack/react-query": "npm:^5"
+    "@tanstack/react-query-devtools": "npm:^5"
     "@types/autosize": "npm:^4.0.3"
     "@types/node": "npm:18.8.3"
     "@types/react": "npm:18.0.21"


### PR DESCRIPTION
## 📋 작업 내용

- [x] tanstack query devtools 추가
- [x] 페이지네이션 오류 수정
- [x] 신청자 관리 필터링/정렬 오류 수정

## 📌 PR Point

query key 리팩토링 하는 과정에서 필터링/정렬에 사용되는 params가 query key에 제대로 들어가지 않는 문제가 있었습니다.
그래서 params이 다른 query들이 같은 key를 갖고 캐싱되면서 필터링/정렬/페이지네이션이 동작하지않았습니다.

모두 수정했고, 수정하는 과정에서 tanstack query devtools도 추가해뒀습니다.
(이슈 분리해서 작업했으면 좋았겠지만,,, 귀찮음 + 시간 이슈로 그냥 요기서 처리했습니다 ㅎㅎ..)

+ 추가로
`management.meta?.pageCount > 0` 요 부분이 데이터가 없으면 아예 필터 + 리스트 + 페이지네이션을 다 안나오게 하고 있어서 지웠습니다.
(필터링 하다가 데이터가 없어지면, 그냥 화면이 없어져버리는 이슈가,,)


## 📸 스크린샷

https://github.com/user-attachments/assets/d9db3805-a79c-4872-afb6-49c195a77736

