### PR TITLE
신청자 리스트 정렬 오류 수정

### DIFF
--- a/src/data/options.ts
+++ b/src/data/options.ts
@@ -8,7 +8,7 @@ export const numberOptionList = [
   { label: '50명씩 보기', value: '50' },
 ];
 
-export const sortOptionListDefault = { label: '최신순', value: 'desc' };
+export const sortOptionListDefault = { label: '오래된 순', value: 'asc' };
 
 export const sortOptionList = [
   { label: '최신순', value: 'desc' },


### PR DESCRIPTION
## 📋 작업 내용

- [x] default 정렬 기준 변경 (최신순 -> 오래된 순)

## 📌 PR Point

처음 신청한 사람이 1번이 되도록 수정

<img width="684" height="449" alt="image" src="https://github.com/user-attachments/assets/ee7f0bd2-1bbf-47ee-aa99-0aeee1ff727d" />

<img width="1483" height="818" alt="image" src="https://github.com/user-attachments/assets/f718c020-bc2c-4bc9-afc1-cccb0e1aeb25" />

신청 `모달`과, `리스트`의 정렬 방식이 달라서 통일했습니다.
