### PR TITLE
모임 개설 - 멘션 리스트 클릭 영역 조정

### DIFF
--- a/src/shared/form/SearchMention/index.tsx
+++ b/src/shared/form/SearchMention/index.tsx
@@ -302,6 +302,7 @@ const SCustomSuggestionsContainer = styled('div', {
 });
 
 const SRenderSuggestion = styled('button', {
+  width: '100%',
   boxSizing: 'border-box',
   padding: '8px 12px',
   gap: '12px',


### PR DESCRIPTION
## 📋 작업 내용

- [x] 멘션 리스트 클릭 영역 조정

## 📌 PR Point
`mention suggestion div`영역을 `100%`로 수정해서 클릭 영역 조정했습니다.

## 📸 스크린샷
**AS-IS**
<img width="910" height="508" alt="image" src="https://github.com/user-attachments/assets/5ba4bfc7-49ee-475f-a77d-3cf4072c5b9d" />



**TO-BE**
<img width="924" height="501" alt="image" src="https://github.com/user-attachments/assets/b76806a8-adaf-4ce2-b025-c557fba1091f" />
