### PR TITLE
Home 레이아웃 리팩토링

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -102,7 +102,7 @@ function MyApp({ Component, pageProps }: AppProps) {
       <MentionProvider>
         <QueryClientProvider client={queryClient}>
           <SEO />
-          {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
+          <ReactQueryDevtools initialIsOpen={false} />
           <Script
             id="gtag-base"
             strategy="afterInteractive"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,4 @@
 import { useFlashListQueryOption } from '@api/flash/query';
-import { useGetPostListInfiniteQuery } from '@api/post/query';
-import { TAKE_COUNT } from '@constant/feed';
-import DesktopFeedListSkeleton from '@domain/detail/Feed/Skeleton/DesktopFeedListSkeleton';
-import MobileFeedListSkeleton from '@domain/detail/Feed/Skeleton/MobileFeedListSkeleton';
 import HomeCardList from '@domain/home/HomeCardList';
 import QuickMenu from '@domain/home/QuickMenu';
 import { useDisplay } from '@hook/useDisplay';
@@ -14,31 +10,17 @@ import GuideButton from '@shared/GuideButton';
 import { Flex } from '@shared/util/layout/Flex';
 import { useQuery } from '@tanstack/react-query';
 import type { NextPage } from 'next';
-import { useEffect } from 'react';
-import { useInView } from 'react-intersection-observer';
 import { styled } from 'stitches.config';
 
 const Home: NextPage = () => {
   const { isLaptop, isTablet } = useDisplay();
-
-  const { ref, inView } = useInView();
-
-  const { fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useGetPostListInfiniteQuery(TAKE_COUNT);
-
   const flashList = useQuery(useFlashListQueryOption()).data?.meetings;
-
-  useEffect(() => {
-    if (inView && hasNextPage) {
-      fetchNextPage();
-    }
-  }, [inView, hasNextPage, fetchNextPage]);
 
   return (
     <>
       <CrewTab>
         <GuideButton />
       </CrewTab>
-      {isLoading && (isTablet ? <MobileFeedListSkeleton count={3} /> : <DesktopFeedListSkeleton row={3} column={3} />)}
       {isTablet ? (
         <>
           <SContentTitle style={{ marginTop: '16px' }}>⚡ 솝트만의 일회성 모임, 번쩍</SContentTitle>
@@ -70,13 +52,6 @@ const Home: NextPage = () => {
             </div>
           </Flex>
         </>
-      )}
-
-      {isFetchingNextPage && isTablet && <MobileFeedListSkeleton count={3} />}
-      {!isFetchingNextPage && hasNextPage ? (
-        <div ref={ref} style={{ height: '1px' }} />
-      ) : (
-        <div style={{ height: '1px' }} />
       )}
 
       <FloatingButton />

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,7 +1,8 @@
+import { isProduction } from '@constant/environment';
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NEXT_PUBLIC_APP_ENV === 'production' ? 'production' : 'development',
+  environment: isProduction ? 'production' : 'development',
   tracesSampleRate: 1.0,
 });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,7 +1,8 @@
+import { isProduction } from '@constant/environment';
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NEXT_PUBLIC_APP_ENV === 'production' ? 'production' : 'development',
+  environment: isProduction ? 'production' : 'development',
   tracesSampleRate: 1.0,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,8 @@
+import { isProduction } from '@constant/environment';
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NEXT_PUBLIC_APP_ENV === 'production' ? 'production' : 'development',
+  environment: isProduction ? 'production' : 'development',
   tracesSampleRate: 1.0,
 });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import { paths } from '@/__generated__/schema';
 import { authToken } from '@/stores/tokenStore';
+import { isProduction } from '@constant/environment';
 import axios from 'axios';
 import { computed } from 'nanostores';
 import createClient from 'openapi-fetch';
@@ -8,15 +9,11 @@ import { checkToken, refreshToken } from './interceptor';
 export type PromiseResponse<T> = { data: T; statusCode: number };
 export type Data<T> = PromiseResponse<T>;
 
-const baseURL =
-  process.env.NEXT_PUBLIC_APP_ENV === 'production' ? 'https://crew.api.prod.sopt.org' : 'https://crew.api.dev.sopt.org';
+const baseURL = isProduction ? 'https://crew.api.prod.sopt.org' : 'https://crew.api.dev.sopt.org';
 
 const authBaseURL = 'https://auth.api.dev.sopt.org';
 
-const playgroundBaseURL =
-  process.env.NEXT_PUBLIC_APP_ENV === 'production'
-    ? 'https://playground.api.sopt.org/'
-    : 'https://playground.dev.sopt.org/';
+const playgroundBaseURL = isProduction ? 'https://playground.api.sopt.org/' : 'https://playground.dev.sopt.org/';
 
 export const baseApi = axios.create({ baseURL });
 

--- a/src/constant/environment.ts
+++ b/src/constant/environment.ts
@@ -1,0 +1,1 @@
+export const isProduction = process.env.NEXT_PUBLIC_APP_ENV === 'production';

--- a/src/constant/url.ts
+++ b/src/constant/url.ts
@@ -1,6 +1,5 @@
-export const playgroundURL =
-  process.env.NEXT_PUBLIC_APP_ENV === 'production'
-    ? `https://playground.sopt.org`
-    : 'https://sopt-internal-dev.pages.dev';
+import { isProduction } from './environment';
+
+export const playgroundURL = isProduction ? `https://playground.sopt.org` : 'https://sopt-internal-dev.pages.dev';
 
 export const imageS3Bucket = 'https://makers-web-img.s3.ap-northeast-2.amazonaws.com/';

--- a/src/domain/home/HomeCardList/CardList.tsx
+++ b/src/domain/home/HomeCardList/CardList.tsx
@@ -20,6 +20,7 @@ const CardList = ({ label, isMore = false, onMoreClick = () => {}, meetingIds }:
   if (!data) return null;
   return (
     <SCardListWrapper>
+      <SGradationRight />
       <STitleWrapper>
         <STitleStyle>{label}</STitleStyle>
         {isMore && <SMoreBtn onClick={onMoreClick}>{'더보기 >'}</SMoreBtn>}
@@ -76,10 +77,25 @@ const SCardListWrapper = styled('section', {
   width: '100%',
   paddingBottom: '$80',
 
-  overflow: 'hidden',
-
   '@tablet': {
     paddingBottom: '$40',
+  },
+});
+
+const SGradationRight = styled('div', {
+  width: '80px',
+  height: '346px',
+  background: 'linear-gradient(270deg, #0F0F12 0%, rgba(15, 15, 18, 0.00) 50%)',
+
+  position: 'absolute',
+  right: '-1px',
+  pointerEvents: 'none',
+
+  '@media (min-width: 1259px)': {
+    display: 'none',
+  },
+  '@media (max-width: 768px)': {
+    display: 'none',
   },
 });
 
@@ -115,5 +131,10 @@ const SCardWrapper = styled('div', {
   '@tablet': {
     flexDirection: 'column',
     width: '100%',
+  },
+
+  '@laptop': {
+    overflow: 'auto',
+    hideScrollbar: true,
   },
 });

--- a/src/domain/home/HomeCardList/DesktopCard.tsx
+++ b/src/domain/home/HomeCardList/DesktopCard.tsx
@@ -63,7 +63,7 @@ const SCardWrapper = styled('article', {
   flexDirection: 'column',
 
   width: '285px',
-  height: '266px',
+  height: '270px',
 });
 
 const SThumbnailImage = styled('img', {

--- a/src/domain/home/HomeCardList/index.tsx
+++ b/src/domain/home/HomeCardList/index.tsx
@@ -11,7 +11,6 @@ const HomeCardList = () => {
 
   return (
     <SWrapper>
-      <SGradationRight />
       {property?.map((prop: { title: string; meetingIds: number[] }, idx: number) => (
         <CardList key={idx} label={prop.title} meetingIds={isProduction ? prop.meetingIds : [540, 667, 645]} />
       ))}
@@ -27,22 +26,5 @@ const SWrapper = styled('div', {
 
   '@laptop': {
     width: '100%',
-  },
-});
-
-const SGradationRight = styled('div', {
-  width: '122px',
-  height: '100%',
-  background: 'linear-gradient(270deg, #0F0F12 0%, rgba(15, 15, 18, 0.00) 100%)',
-
-  position: 'absolute',
-  right: '-1px',
-  pointerEvents: 'none',
-
-  '@media (min-width: 1259px)': {
-    display: 'none',
-  },
-  '@media (max-width: 768px)': {
-    display: 'none',
   },
 });

--- a/src/domain/home/HomeCardList/index.tsx
+++ b/src/domain/home/HomeCardList/index.tsx
@@ -1,4 +1,5 @@
 import { usePropertyQueryOption } from '@api/property/hooks';
+import { isProduction } from '@constant/environment';
 import CardList from '@domain/home/HomeCardList/CardList';
 import { useQuery } from '@tanstack/react-query';
 import { styled } from 'stitches.config';
@@ -12,7 +13,7 @@ const HomeCardList = () => {
     <SWrapper>
       <SGradationRight />
       {property?.map((prop: { title: string; meetingIds: number[] }, idx: number) => (
-        <CardList key={idx} label={prop.title} meetingIds={prop.meetingIds} />
+        <CardList key={idx} label={prop.title} meetingIds={isProduction ? prop.meetingIds : [540, 667, 645]} />
       ))}
     </SWrapper>
   );

--- a/stitches.config.ts
+++ b/stitches.config.ts
@@ -454,6 +454,14 @@ const stitches = createStitches({
         },
       },
     }),
+    hideScrollbar: (value: boolean) =>
+      value
+        ? {
+            scrollbarWidth: 'none',
+            msOverflowStyle: 'none',
+            '&::-webkit-scrollbar': { display: 'none' },
+          }
+        : {},
   },
 });
 


### PR DESCRIPTION
## 📋 작업 내용

- [x] Home Card List 좌우 스크롤 추가
- [x] 배포 환경 구분 변수(isProduction) 추가
- [x] 홈화면 피드 무한스크롤 코드 삭제

## 📌 PR Point

<img width="844" height="741" alt="image" src="https://github.com/user-attachments/assets/9f2eead8-625a-4dc0-aba2-c85c2cea79cf" />

- 841px ~ 1259px 구간에서 editable 컨텐츠 영역이 짤리고, 스크롤도 안되는 문제가 있었습니다.
- 좌우 스크롤 추가했습니다.
- 작업하면서 isProduction 변수가 필요해서 추가하고, 프로젝트 전체에 사용되는 부분 반영했습니다.
- 홈화면 맨 밑으로 내리면 피드를 계속 다시 불러오는 레거시 코드 삭제했습니다.


##  스크린샷

https://github.com/user-attachments/assets/e14d6880-2c3d-4087-9ed0-4864926bf73d
