### PR TITLE
정렬 기본값 변경

### DIFF
--- a/src/data/options.ts
+++ b/src/data/options.ts
@@ -11,8 +11,8 @@ export const numberOptionList = [
 export const sortOptionListDefault = { label: '오래된 순', value: 'asc' };
 
 export const sortOptionList = [
-  { label: '최신순', value: 'desc' },
   { label: '오래된 순', value: 'asc' },
+  { label: '최신순', value: 'desc' },
 ];
 
 export const generationOptions = [


### PR DESCRIPTION
## 📋 작업 내용

- [x] 정렬 기준 기본값 변경 (최신순 -> 오래된 순)

## 📌 PR Point

#1199 PR에서 `sortOptionListDefault` 를 수정했는데,
`sortOptionList` 의 순서도 바꿔야해서 수정했습니다.

<img width="282" height="181" alt="image" src="https://github.com/user-attachments/assets/f9e88344-0dde-4f88-99b6-95d94b4b5340" />

이제 이런 select 에서도 오래된 순이 먼저 나오고,
신청자 리스트 조회 등에서도 먼저 신청한 사람의 번호가 더 작게 나옵니다. (처음 신청한 사람이 1번)

## 📸 스크린샷

<img width="850" height="714" alt="image" src="https://github.com/user-attachments/assets/6a5acc15-dba4-4730-ae22-81977dc61045" />

