### PR TITLE
member list invalidate 안되는 문제 해결

### DIFF
--- a/src/api/meeting/mutation.ts
+++ b/src/api/meeting/mutation.ts
@@ -60,7 +60,9 @@ export const useUpdateMeetingApplicationMutation = (meetingId: string) => {
     mutationFn: updateMeetingApplication,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: MeetingQueryKey.memberList(meetingId),
+        // TODO: queryKey 타입 문제 해결 후 주석 해제
+        // queryKey: MeetingQueryKey.memberList(meetingId),
+        queryKey: ['meeting', 'memberList', meetingId],
       });
     },
     onError: (error: unknown) => {


### PR DESCRIPTION
## 📋 작업 내용

- [x] member list invalidate 안되는 문제 해결

## 📌 PR Point
문제를 확인해보니까 승인/승인 취소 query `onSuccess`에서 `invalidate`를 `memberList`를 해주고 있긴한데, 이전에 페이지네이션 문제로 `params`를 추가한 부분에서 문제가 생긴 것을 확인할 수 있었어요.

```tsx
const MeetingQueryKey = {
  // 생략... 
  memberList: (meetingId: string, params?: GetMeetingMemberList['request']) =>
    [...MeetingQueryKey.all(), 'memberList', meetingId, params] as const,
};


```queryKey가 이렇게 이루어져 있는데, `params`는 초기에 필터링 값이 없기 때문에 optional을 주게 되었어요.
그러다 보니 `invalidate`하는 코드에서는 
```tsx
onSuccess: () => {
      queryClient.invalidateQueries({
         queryKey: MeetingQueryKey.memberList(meetingId),
      });
    },
```

meetingId만 주고 있고, params를 안주다 보니 params가 undefined로 설정돼요.
queryKey는 앞에서부터 순차적으로 기준을 추가하는데, invalidate에서 지정하는 queryKey도 meetingId까지는 똑같지만 optional로 인해서 undefined가 queryKey맨 끝에 위치하게 되고 무효화하는 쿼리키가 달라서 적용이 되지 않는 것이 원인이었어요.

<img width="465" height="93" alt="image" src="https://github.com/user-attachments/assets/8ae7e506-ed1e-4afb-8804-4dab6b1f4d49" />

따라서 일단 급한대로  `queryKey: ['meeting', 'memberList', meetingId],` 이렇게 문자열로 queryKey를 지정해서 앞 3개가 같은 쿼리키에 대해서 무효화를 시켜주도록 설정해서 해결했어요.

이후에 쿼리키 설정에 대해서 그리고 해당 `params`문제에 대해서 다시 얘기해보면 좋을 것 같아요.

