### PR TITLE
device에 따른 userAgent logging

### DIFF
--- a/src/domain/map/Card/index.tsx
+++ b/src/domain/map/Card/index.tsx
@@ -40,13 +40,20 @@ const MapCard = ({ mapData }: MapCardProps) => {
   const handleOpenUrl = (url: string | undefined) => {
     if (!url) return;
 
+    // 임시 디버깅용
+    alert(`UA: ${navigator.userAgent}\nisMobile: ${isMobile}`);
+
     let targetUrl = url;
 
     if (!isMobile && targetUrl.startsWith(NAVER_MAP_APP_URL_PREFIX)) {
       targetUrl = targetUrl.replace(NAVER_MAP_APP_URL_PREFIX, 'https://');
+      window.open(targetUrl, '_blank');
+      return;
     }
 
-    window.open(targetUrl, '_blank');
+    if (isMobile) {
+      window.location.href = targetUrl;
+    }
   };
 
   const handleLinkMove = () => {


### PR DESCRIPTION
## 📋 작업 내용

- [x] userAgent 확인용 alert 추가

## 📌 PR Point
device에 따른 userAgent logging을 위해서 확인용 alert 추가하였습니다.

솝맵 장소 링크 이동에서 device(mobile/desktop)에 따라 리다이렉트를 분기처리하였는데,
desktop에서는 nmap이 https로 잘 변환됨을 확인했지만, mobile에서 이전 에러가 뜨는 것을 확인했습니다.

이게 웹뷰라 앱 문제인지 웹 문제인지 확인하기가 힘들고 혹시나 웹 뷰에서 userAgent가 저희가 생각한 값이랑 다를 case가 있을지 몰라 dev에만 임시로 확인하도록 log 추가했습니다.


## 📸 스크린샷
### 문제 상황
https://github.com/user-attachments/assets/abd24193-34c5-4fa1-bfce-96e114d3eb01

