### PR TITLE
솝맵 카드 Truncate(말줄임표) 제거 및 break-all 처리

### DIFF
--- a/src/domain/map/Card/DesktopMapCard/index.tsx
+++ b/src/domain/map/Card/DesktopMapCard/index.tsx
@@ -49,7 +49,7 @@ const DesktopMapCard = ({ onDelete, onEdit, onLinkClick, onRecommendClick, mapDa
         <SDivider />
 
         <Flex align="center" justify="between">
-          <Flex align="center" css={{ gap: '8px', flex: 1, minWidth: 0 }}>
+          <Flex align="start" css={{ gap: '8px', flex: 1, minWidth: 0 }}>
             {mapData?.isCreator && (
               <Tag variant="default" size="md">
                 내가 등록한 장소
@@ -141,13 +141,12 @@ const SDivider = styled('div', {
 
 const SInfoWrapper = styled('div', {
   display: 'flex',
-  alignItems: 'center',
+  alignItems: 'start',
   gap: '2px',
   ...fontsObject.BODY_3_14_L,
   flex: 1,
   minWidth: 0,
   '& p': {
-    whiteSpace: 'nowrap',
     flexShrink: 0,
   },
 });
@@ -160,12 +159,10 @@ const SSeparator = styled('span', {
 const SDescription = styled('p', {
   color: '$gray300',
 
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-
   flex: 1,
   minWidth: 0,
+
+  wordBreak: 'break-all',
 });
 
 const SEditButtonWrapper = styled('div', {

--- a/src/domain/map/Card/MobileMapCard/index.tsx
+++ b/src/domain/map/Card/MobileMapCard/index.tsx
@@ -56,7 +56,7 @@ const MobileMapCard = ({ onDelete, onEdit, onLinkClick, onRecommendClick, mapDat
         </Flex>
         <SSubwayStation>{mapData?.subwayStationNames?.join(', ')}</SSubwayStation>
         <SInfoWrapper>
-          <p>{mapData?.creatorName}</p>
+          <SCreatorName>{mapData?.creatorName}</SCreatorName>
           <SSeparator>∙</SSeparator>
           <SDescription>{mapData?.description}</SDescription>
         </SInfoWrapper>
@@ -141,7 +141,6 @@ const SInfoWrapper = styled('div', {
   ...fontsObject.BODY_4_13_M,
 
   '& p': {
-    whiteSpace: 'nowrap',
     flexShrink: 0,
   },
 
@@ -156,20 +155,23 @@ const SInfoWrapper = styled('div', {
   },
 });
 
+const SCreatorName = styled('p', {
+  alignSelf: 'flex-start',
+});
+
 const SSeparator = styled('span', {
   color: '$gray300',
+  alignSelf: 'flex-start',
   flexShrink: 0,
 });
 
 const SDescription = styled('p', {
   color: '$gray300',
 
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-
   flex: 1,
   minWidth: 0,
+
+  wordBreak: 'break-word',
 });
 
 const SMoreButton = styled(IconDotsVertical, {

--- a/src/domain/map/Card/MobileMapCard/index.tsx
+++ b/src/domain/map/Card/MobileMapCard/index.tsx
@@ -171,7 +171,7 @@ const SDescription = styled('p', {
   flex: 1,
   minWidth: 0,
 
-  wordBreak: 'break-word',
+  wordBreak: 'break-all',
 });
 
 const SMoreButton = styled(IconDotsVertical, {


### PR DESCRIPTION
## 📋 작업 내용
솝맵 카드 Truncate(말줄임표) 제거 및 break-all 처리

## 📌 PR Point
솝맵은 상세페이지가 없어 리스트에서 모든 description이 보여야 하는 이유로 디자인 요청에 따라
runcate(말줄임표)를 제거하고, break-all 처리로 변경 했습니다.

## 📸 스크린샷
### Desktop
<img width="1117" height="894" alt="image" src="https://github.com/user-attachments/assets/5e7961c9-5a8a-4371-86b0-00f29465de00" />

### Mobile
<img width="388" height="845" alt="image" src="https://github.com/user-attachments/assets/515baa2c-1f25-4ce2-a8df-15546f669a56" />
